### PR TITLE
fix(boardRead): #MAG-159 unroll the select when clicking on the label

### DIFF
--- a/src/main/resources/public/template/board-read.html
+++ b/src/main/resources/public/template/board-read.html
@@ -8,13 +8,13 @@
     <div class="section-container">
         <nav ng-if="!vm.board.isLayoutFree()" class="nav-container">
             <ul>
-                <li class="li-container">
+                <li class="li-container" ng-click="vm.openSection()">
                     <span>[[vm.section.title]] </span>
                     <div>
-                        <i ng-if="!vm.filter.showSection" class="magneto-chevron-down show-section"
-                           ng-click="vm.openSection()"></i>
-                        <i  ng-if="vm.filter.showSection" class="magneto-chevron-up show-section"
-                           ng-click="vm.openSection()"></i>
+                        <i ng-if="!vm.filter.showSection"
+                           class="magneto-chevron-down show-section"></i>
+                        <i  ng-if="vm.filter.showSection"
+                            class="magneto-chevron-up show-section"></i>
                     </div>
                 <li ng-show="vm.filter.showSection">
                     <ul>


### PR DESCRIPTION
## Describe your changes
Added the label in the clickable area with the arrow to unroll the select.

## Checklist tests
You can go on "Magneto" module --> Create a table (with sections) --> Have at least 2 sections --> And at least 1 magnet per section --> click on "Lecture" --> You should be able to click on the whole label + arrow to unroll the select.

## Issue ticket number and link
[MAG-159](https://jira.support-ent.fr/browse/MAG-159)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

