### PR TITLE
fix(board): #MAG-128 line breaks are displayed in board description

### DIFF
--- a/src/main/resources/public/template/board.html
+++ b/src/main/resources/public/template/board.html
@@ -17,9 +17,7 @@
                 <board-date date="vm.board.modificationDate"></board-date>
             </div>
         </div>
-        <div ng-if="!!vm.board.description" class="board-container-header-description">
-            [[vm.board.description]]
-        </div>
+        <div ng-if="!!vm.board.description" class="board-container-header-description" ng-bind="vm.board.description"></div>
     </div>
 
     <!-- Header mobile -->
@@ -41,9 +39,7 @@
             </button>
 
         </div>
-        <div ng-if="!!vm.board.description" class="board-container-header-description">
-            [[vm.board.description]]
-        </div>
+        <div ng-if="!!vm.board.description" class="board-container-header-description" ng-bind="vm.board.description"></div>
     </div>
 
     <div class="twelve cell board-container-body"


### PR DESCRIPTION
## Describe your changes
Make changes to display line breaks on board description.

CSS PR : 
https://github.com/CGI-OPEN-ENT-NG/entcore-css-lib/pull/62

## Checklist tests
Go to "Magneto" module --> create a board with description or add one with line breaks --> open the board and check the description displayed.

## Issue ticket number and link
[MAG-128](https://jira.support-ent.fr/browse/MAG-128)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

