### PR TITLE
fix(boardRead): #MAG-172 don't display arrow for one card

### DIFF
--- a/src/main/resources/public/template/board-read.html
+++ b/src/main/resources/public/template/board-read.html
@@ -47,6 +47,6 @@
         <i class="magneto-chevron-left nav-left" ng-if="vm.filter.page > 0" ng-click="vm.previousPage()"></i>
     </div>
     <div class="button-next">
-        <i class="magneto-chevron-right nav-right" ng-if="!vm.isLastPage()" ng-click="vm.nextPage()"></i>
+        <i class="magneto-chevron-right nav-right" ng-if="!vm.isLastPage() && !vm.isLoading" ng-click="vm.nextPage()"></i>
     </div>
 </div>

--- a/src/main/resources/public/ts/controllers/board-read.controller.ts
+++ b/src/main/resources/public/ts/controllers/board-read.controller.ts
@@ -1,4 +1,4 @@
-import {ng, notify} from "entcore";
+import {ng, notify, angular} from "entcore";
 import {IScope} from "angular";
 import {IBoardsService, ICardsService, ISectionsService} from "../services";
 import {Board, Boards, Card, Section, Sections} from "../models";
@@ -78,10 +78,6 @@ class Controller implements ng.IController, IViewModel {
         };
 
         this.board = new Board();
-        this.getBoard()
-            .then(() => this.getCard())
-            .then(() => this.filter.count = this.board.isLayoutFree() ? this.board.cardIds.length : this.board.cardIdsSection().length);
-
         this.changePageSubject = new Subject<string>();
     }
 
@@ -89,6 +85,11 @@ class Controller implements ng.IController, IViewModel {
         $(document).on('keydown', (event: JQueryEventObject) => {
             this.changePage(event);
         });
+
+        this.getBoard()
+            .then(() => this.getCard())
+            .then(() => this.filter.count = this.board.isLayoutFree() ? this.board.cardIds.length : this.board.cardIdsSection().length);
+
         safeApply(this.$scope);
     }
 

--- a/src/main/resources/public/ts/controllers/board-read.controller.ts
+++ b/src/main/resources/public/ts/controllers/board-read.controller.ts
@@ -89,6 +89,7 @@ class Controller implements ng.IController, IViewModel {
         $(document).on('keydown', (event: JQueryEventObject) => {
             this.changePage(event);
         });
+        safeApply(this.$scope);
     }
 
     /**

--- a/src/main/resources/public/ts/controllers/board-read.controller.ts
+++ b/src/main/resources/public/ts/controllers/board-read.controller.ts
@@ -50,6 +50,7 @@ class Controller implements ng.IController, IViewModel {
     card: Card;
     section: Section;
     board: Board;
+    isLoading: boolean;
 
     changePageSubject: Subject<string>;
 
@@ -76,6 +77,7 @@ class Controller implements ng.IController, IViewModel {
             boardId: (this.$route.current && this.$route.current.params) ? this.$route.current.params.boardId : null,
             showSection: false
         };
+        this.isLoading = true;
 
         this.board = new Board();
         this.changePageSubject = new Subject<string>();
@@ -90,6 +92,7 @@ class Controller implements ng.IController, IViewModel {
             .then(() => this.getCard())
             .then(() => {
                 this.filter.count = this.board.isLayoutFree() ? this.board.cardIds.length : this.board.cardIdsSection().length;
+                this.isLoading = false;
                 safeApply(this.$scope);
             });
 

--- a/src/main/resources/public/ts/controllers/board-read.controller.ts
+++ b/src/main/resources/public/ts/controllers/board-read.controller.ts
@@ -126,7 +126,7 @@ class Controller implements ng.IController, IViewModel {
     async changePage($event: JQueryEventObject): Promise<void> {
         if($event.keyCode === KEYCODE.ARROW_LEFT && this.filter.page > 0) {
             await this.previousPage();
-        } else if($event.keyCode === KEYCODE.ARROW_RIGHT && !this.isLastPage()) {
+        } else if($event.keyCode === KEYCODE.ARROW_RIGHT && !this.isLastPage() && !this.isLoading) {
             await this.nextPage();
         }
     }

--- a/src/main/resources/public/ts/controllers/board-read.controller.ts
+++ b/src/main/resources/public/ts/controllers/board-read.controller.ts
@@ -1,4 +1,4 @@
-import {ng, notify, angular} from "entcore";
+import {ng, notify} from "entcore";
 import {IScope} from "angular";
 import {IBoardsService, ICardsService, ISectionsService} from "../services";
 import {Board, Boards, Card, Section, Sections} from "../models";
@@ -88,7 +88,10 @@ class Controller implements ng.IController, IViewModel {
 
         this.getBoard()
             .then(() => this.getCard())
-            .then(() => this.filter.count = this.board.isLayoutFree() ? this.board.cardIds.length : this.board.cardIdsSection().length);
+            .then(() => {
+                this.filter.count = this.board.isLayoutFree() ? this.board.cardIds.length : this.board.cardIdsSection().length;
+                safeApply(this.$scope);
+            });
 
         safeApply(this.$scope);
     }


### PR DESCRIPTION
## Describe your changes
Add safeApply in asychronous call to fix arrow display when there is only one card in board-read.

## Checklist tests
Module "Magneto" --> Create or open a board --> you need to have only one card --> button "Lecture" --> no arrow should be displayed

## Issue ticket number and link
[MAG-172](https://jira.support-ent.fr/browse/MAG-172)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

