### PR TITLE
fix(boardRead): #MAG-174 fix error on nav arrow in board read

### DIFF
--- a/src/main/resources/public/ts/controllers/board-read.controller.ts
+++ b/src/main/resources/public/ts/controllers/board-read.controller.ts
@@ -220,6 +220,7 @@ class Controller implements ng.IController, IViewModel {
     }
 
     $onDestroy() {
+        $(document).off('keydown');
     }
 
 }

--- a/src/main/resources/public/ts/controllers/board-read.controller.ts
+++ b/src/main/resources/public/ts/controllers/board-read.controller.ts
@@ -61,6 +61,8 @@ class Controller implements ng.IController, IViewModel {
         showSection: boolean;
     };
 
+    handlerChangePage: (eventObject: JQueryEventObject, ...args: any[]) => any
+
 
     constructor(private $scope: ICardsScope,
                 private $route: any,
@@ -81,12 +83,13 @@ class Controller implements ng.IController, IViewModel {
 
         this.board = new Board();
         this.changePageSubject = new Subject<string>();
+        this.handlerChangePage = (event: JQueryEventObject) => {
+            this.changePage(event).then();
+        };
     }
 
     async $onInit(): Promise<void> {
-        $(document).on('keydown', (event: JQueryEventObject) => {
-            this.changePage(event);
-        });
+        $(document).on('keydown', this.handlerChangePage);
 
         this.getBoard()
             .then(() => this.getCard())
@@ -220,7 +223,7 @@ class Controller implements ng.IController, IViewModel {
     }
 
     $onDestroy() {
-        $(document).off('keydown');
+        $(document).off('keydown', this.handlerChangePage);
     }
 
 }


### PR DESCRIPTION
## Describe your changes
Destroy keydown event to prevent error after initialising it and use it in board read.

## Checklist tests
Module "Magneto" --> Create or open a board --> you need to have at least two cards --> button "Lecture" --> user nav arrow to switch cards --> button "Retour" --> try to use nav arrow, nothing should happen.

## Issue ticket number and link
[MAG-174](https://jira.support-ent.fr/browse/MAG-174)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

