### PR TITLE
feat(favorite): #MAG-218 add option in board property to display number of favorites per cards or not

### DIFF
--- a/src/main/java/fr/cgi/magneto/controller/BoardController.java
+++ b/src/main/java/fr/cgi/magneto/controller/BoardController.java
@@ -139,6 +139,10 @@ public class BoardController extends ControllerHelper {
                             if (!hasCommRight) {
                                 board.remove(Field.CANCOMMENT);
                             }
+                            boolean hasDisplayNbOfFavoritesRight = WorkflowHelper.hasRight(user, Rights.DISPLAY_NB_OF_FAVORITES);
+                            if (!hasDisplayNbOfFavoritesRight) {
+                                board.remove(Field.DISPLAY_NB_OF_FAVORITES);
+                            }
                             boardService.create(user, board, true, i18nHelper)
                                     .onFailure(err -> renderError(request))
                                     .onSuccess(result -> {
@@ -181,6 +185,10 @@ public class BoardController extends ControllerHelper {
                                 boolean hasCommRight = WorkflowHelper.hasRight(user, Rights.COMMENT_BOARD);
                                 if (!hasCommRight) {
                                     board.remove(Field.CANCOMMENT);
+                                }
+                                boolean hasDisplayNbOfFavoritesRight = WorkflowHelper.hasRight(user, Rights.DISPLAY_NB_OF_FAVORITES);
+                                if(!hasDisplayNbOfFavoritesRight) {
+                                    board.remove(Field.DISPLAY_NB_OF_FAVORITES);
                                 }
                                 BoardPayload updateBoard = new BoardPayload(board)
                                         .setId(boardId)

--- a/src/main/java/fr/cgi/magneto/controller/BoardController.java
+++ b/src/main/java/fr/cgi/magneto/controller/BoardController.java
@@ -139,9 +139,9 @@ public class BoardController extends ControllerHelper {
                             if (!hasCommRight) {
                                 board.remove(Field.CANCOMMENT);
                             }
-                            boolean hasDisplayNbOfFavoritesRight = WorkflowHelper.hasRight(user, Rights.DISPLAY_NB_OF_FAVORITES);
-                            if (!hasDisplayNbOfFavoritesRight) {
-                                board.remove(Field.DISPLAY_NB_OF_FAVORITES);
+                            boolean hasDisplayNbFavoritesRight = WorkflowHelper.hasRight(user, Rights.DISPLAY_NB_FAVORITES);
+                            if (!hasDisplayNbFavoritesRight) {
+                                board.remove(Field.DISPLAY_NB_FAVORITES);
                             }
                             boardService.create(user, board, true, i18nHelper)
                                     .onFailure(err -> renderError(request))
@@ -186,9 +186,9 @@ public class BoardController extends ControllerHelper {
                                 if (!hasCommRight) {
                                     board.remove(Field.CANCOMMENT);
                                 }
-                                boolean hasDisplayNbOfFavoritesRight = WorkflowHelper.hasRight(user, Rights.DISPLAY_NB_OF_FAVORITES);
-                                if(!hasDisplayNbOfFavoritesRight) {
-                                    board.remove(Field.DISPLAY_NB_OF_FAVORITES);
+                                boolean hasDisplayNbFavoritesRight = WorkflowHelper.hasRight(user, Rights.DISPLAY_NB_FAVORITES);
+                                if(!hasDisplayNbFavoritesRight) {
+                                    board.remove(Field.DISPLAY_NB_FAVORITES);
                                 }
                                 BoardPayload updateBoard = new BoardPayload(board)
                                         .setId(boardId)

--- a/src/main/java/fr/cgi/magneto/controller/FakeRight.java
+++ b/src/main/java/fr/cgi/magneto/controller/FakeRight.java
@@ -28,7 +28,7 @@ public class FakeRight extends ControllerHelper {
     }
 
     @Get("/rights/board/favorites")
-    @SecuredAction(Rights.DISPLAY_NB_OF_FAVORITES)
+    @SecuredAction(Rights.DISPLAY_NB_FAVORITES)
     public void boardFavorites(HttpServerRequest request) {
         notImplemented(request);
     }

--- a/src/main/java/fr/cgi/magneto/controller/FakeRight.java
+++ b/src/main/java/fr/cgi/magneto/controller/FakeRight.java
@@ -27,4 +27,9 @@ public class FakeRight extends ControllerHelper {
         notImplemented(request);
     }
 
+    @Get("/rights/board/favorites")
+    @SecuredAction(Rights.DISPLAY_NB_OF_FAVORITES)
+    public void boardFavorites(HttpServerRequest request) {
+        notImplemented(request);
+    }
 }

--- a/src/main/java/fr/cgi/magneto/core/constants/Field.java
+++ b/src/main/java/fr/cgi/magneto/core/constants/Field.java
@@ -65,6 +65,7 @@ public class Field {
     public static final String LAYOUTTYPE = "layoutType";
 
     public static final String CANCOMMENT = "canComment";
+    public static final String DISPLAY_NB_OF_FAVORITES = "displayNbOfFavorites";
 
     public static final String OWNER = "owner";
     public static final String USERID = "userId";

--- a/src/main/java/fr/cgi/magneto/core/constants/Field.java
+++ b/src/main/java/fr/cgi/magneto/core/constants/Field.java
@@ -65,7 +65,7 @@ public class Field {
     public static final String LAYOUTTYPE = "layoutType";
 
     public static final String CANCOMMENT = "canComment";
-    public static final String DISPLAY_NB_OF_FAVORITES = "displayNbOfFavorites";
+    public static final String DISPLAY_NB_FAVORITES = "displayNbFavorites";
 
     public static final String OWNER = "owner";
     public static final String USERID = "userId";

--- a/src/main/java/fr/cgi/magneto/core/constants/Rights.java
+++ b/src/main/java/fr/cgi/magneto/core/constants/Rights.java
@@ -27,7 +27,7 @@ public class Rights {
      * - add/remove ability to display number of favorites from cards of a board
      */
 
-    public static final String DISPLAY_NB_OF_FAVORITES = "magneto.board.favorites";
+    public static final String DISPLAY_NB_FAVORITES = "magneto.board.favorites";
 
     /** === SHARING RIGHTS === */
 

--- a/src/main/java/fr/cgi/magneto/core/constants/Rights.java
+++ b/src/main/java/fr/cgi/magneto/core/constants/Rights.java
@@ -22,6 +22,12 @@ public class Rights {
      */
     public static final String COMMENT_BOARD = "magneto.board.comment";
 
+    /**
+     * Right :
+     * - add/remove ability to display number of favorites from cards of a board
+     */
+
+    public static final String DISPLAY_NB_OF_FAVORITES = "magneto.board.favorites";
 
     /** === SHARING RIGHTS === */
 

--- a/src/main/java/fr/cgi/magneto/model/boards/BoardPayload.java
+++ b/src/main/java/fr/cgi/magneto/model/boards/BoardPayload.java
@@ -23,6 +23,8 @@ public class BoardPayload implements Model<BoardPayload> {
     private String folderId;
     private String layoutType;
     private Boolean canComment;
+
+    private Boolean displayNbOfFavorites;
     private List<String> cardIds;
     private List<String> sectionIds;
 
@@ -46,6 +48,9 @@ public class BoardPayload implements Model<BoardPayload> {
         this.layoutType = board.getString(Field.LAYOUTTYPE);
         if (board.getBoolean(Field.CANCOMMENT) != null) {
             this.canComment = board.getBoolean(Field.CANCOMMENT, false);
+        }
+        if(board.getBoolean(Field.DISPLAY_NB_OF_FAVORITES) != null) {
+            this.displayNbOfFavorites = board.getBoolean(Field.DISPLAY_NB_OF_FAVORITES, false);
         }
         this.cardIds = !board.getJsonArray(Field.CARDIDS, new JsonArray()).isEmpty() ?
                 board.getJsonArray(Field.CARDIDS, new JsonArray()).getList() : null;
@@ -156,6 +161,15 @@ public class BoardPayload implements Model<BoardPayload> {
 
     public BoardPayload setCanComment(Boolean canComment) {
         this.canComment = canComment;
+        return this;
+    }
+
+    public Boolean displayNbOfFavorites() {
+        return displayNbOfFavorites;
+    }
+
+    public BoardPayload setDisplayNbOfFavorites(Boolean displayNbOfFavorites) {
+        this.displayNbOfFavorites = displayNbOfFavorites;
         return this;
     }
 
@@ -294,6 +308,10 @@ public class BoardPayload implements Model<BoardPayload> {
 
         if (this.canComment() != null) {
             json.put(Field.CANCOMMENT, this.canComment());
+        }
+
+        if (this.displayNbOfFavorites() != null) {
+            json.put(Field.DISPLAY_NB_OF_FAVORITES, this.displayNbOfFavorites());
         }
 
         json.put(Field.PUBLIC, this.isPublic());

--- a/src/main/java/fr/cgi/magneto/model/boards/BoardPayload.java
+++ b/src/main/java/fr/cgi/magneto/model/boards/BoardPayload.java
@@ -24,7 +24,7 @@ public class BoardPayload implements Model<BoardPayload> {
     private String layoutType;
     private Boolean canComment;
 
-    private Boolean displayNbOfFavorites;
+    private Boolean displayNbFavorites;
     private List<String> cardIds;
     private List<String> sectionIds;
 
@@ -49,8 +49,8 @@ public class BoardPayload implements Model<BoardPayload> {
         if (board.getBoolean(Field.CANCOMMENT) != null) {
             this.canComment = board.getBoolean(Field.CANCOMMENT, false);
         }
-        if(board.getBoolean(Field.DISPLAY_NB_OF_FAVORITES) != null) {
-            this.displayNbOfFavorites = board.getBoolean(Field.DISPLAY_NB_OF_FAVORITES, false);
+        if(board.getBoolean(Field.DISPLAY_NB_FAVORITES) != null) {
+            this.displayNbFavorites = board.getBoolean(Field.DISPLAY_NB_FAVORITES, false);
         }
         this.cardIds = !board.getJsonArray(Field.CARDIDS, new JsonArray()).isEmpty() ?
                 board.getJsonArray(Field.CARDIDS, new JsonArray()).getList() : null;
@@ -164,12 +164,12 @@ public class BoardPayload implements Model<BoardPayload> {
         return this;
     }
 
-    public Boolean displayNbOfFavorites() {
-        return displayNbOfFavorites;
+    public Boolean displayNbFavorites() {
+        return displayNbFavorites;
     }
 
-    public BoardPayload setDisplayNbOfFavorites(Boolean displayNbOfFavorites) {
-        this.displayNbOfFavorites = displayNbOfFavorites;
+    public BoardPayload setDisplayNbFavorites(Boolean displayNbFavorites) {
+        this.displayNbFavorites = displayNbFavorites;
         return this;
     }
 
@@ -310,8 +310,8 @@ public class BoardPayload implements Model<BoardPayload> {
             json.put(Field.CANCOMMENT, this.canComment());
         }
 
-        if (this.displayNbOfFavorites() != null) {
-            json.put(Field.DISPLAY_NB_OF_FAVORITES, this.displayNbOfFavorites());
+        if (this.displayNbFavorites() != null) {
+            json.put(Field.DISPLAY_NB_FAVORITES, this.displayNbFavorites());
         }
 
         json.put(Field.PUBLIC, this.isPublic());

--- a/src/main/java/fr/cgi/magneto/service/impl/DefaultBoardService.java
+++ b/src/main/java/fr/cgi/magneto/service/impl/DefaultBoardService.java
@@ -475,7 +475,7 @@ public class DefaultBoardService implements BoardService {
                             .put(Field.PUBLIC, 1)
                             .put(Field.DELETED, 1)
                             .put(Field.CANCOMMENT, 1)
-                            .put(Field.DISPLAY_NB_OF_FAVORITES, 1)
+                            .put(Field.DISPLAY_NB_FAVORITES, 1)
                     )
                     .unwind(Field.FOLDERID, true);
         }
@@ -506,7 +506,7 @@ public class DefaultBoardService implements BoardService {
                 .put(Field.LAYOUTTYPE, 1)
                 .put(Field.PUBLIC, 1)
                 .put(Field.CANCOMMENT, 1)
-                .put(Field.DISPLAY_NB_OF_FAVORITES, 1));
+                .put(Field.DISPLAY_NB_FAVORITES, 1));
         if (getCount) {
             query = query.count();
         }
@@ -561,7 +561,7 @@ public class DefaultBoardService implements BoardService {
                         .put(Field.TAGS, 1)
                         .put(Field.PUBLIC, 1)
                         .put(Field.CANCOMMENT, 1)
-                        .put(Field.DISPLAY_NB_OF_FAVORITES, 1));
+                        .put(Field.DISPLAY_NB_FAVORITES, 1));
         return query.getAggregate();
     }
 }

--- a/src/main/java/fr/cgi/magneto/service/impl/DefaultBoardService.java
+++ b/src/main/java/fr/cgi/magneto/service/impl/DefaultBoardService.java
@@ -474,7 +474,9 @@ public class DefaultBoardService implements BoardService {
                             .put(Field.TAGS, 1)
                             .put(Field.PUBLIC, 1)
                             .put(Field.DELETED, 1)
-                            .put(Field.CANCOMMENT, 1))
+                            .put(Field.CANCOMMENT, 1)
+                            .put(Field.DISPLAY_NB_OF_FAVORITES, 1)
+                    )
                     .unwind(Field.FOLDERID, true);
         }
 
@@ -503,7 +505,8 @@ public class DefaultBoardService implements BoardService {
                 .put(Field.TAGS, 1)
                 .put(Field.LAYOUTTYPE, 1)
                 .put(Field.PUBLIC, 1)
-                .put(Field.CANCOMMENT, 1));
+                .put(Field.CANCOMMENT, 1)
+                .put(Field.DISPLAY_NB_OF_FAVORITES, 1));
         if (getCount) {
             query = query.count();
         }
@@ -557,7 +560,8 @@ public class DefaultBoardService implements BoardService {
                         .put(Field.SHARED, 1)
                         .put(Field.TAGS, 1)
                         .put(Field.PUBLIC, 1)
-                        .put(Field.CANCOMMENT, 1));
+                        .put(Field.CANCOMMENT, 1)
+                        .put(Field.DISPLAY_NB_OF_FAVORITES, 1));
         return query.getAggregate();
     }
 }

--- a/src/main/resources/i18n/de.json
+++ b/src/main/resources/i18n/de.json
@@ -184,6 +184,6 @@
   "magneto.dropzone.overlay.warning": "Il est impossible d'importer un dossier",
   "magneto.dropzone.overlay.solution": "Veuillez importer un <b>fichier</b>",
   "magneto.dropzone.overlay.action": "J'ai compris",
-  "magneto.shared.push.notif.body": "shared a board with you"
-
+  "magneto.shared.push.notif.body": "shared a board with you",
+  "magneto.create.board.options.display.favorites": "Afficher le nombre de likes sur un écran pour les destinataires du tableau"
 }

--- a/src/main/resources/i18n/en.json
+++ b/src/main/resources/i18n/en.json
@@ -184,5 +184,6 @@
   "magneto.dropzone.overlay.warning": "Il est impossible d'importer un dossier",
   "magneto.dropzone.overlay.solution": "Veuillez importer un <b>fichier</b>",
   "magneto.dropzone.overlay.action": "J'ai compris",
-  "magneto.shared.push.notif.body": "shared a board with you"
+  "magneto.shared.push.notif.body": "shared a board with you",
+  "magneto.create.board.options.display.favorites": "Afficher le nombre de likes sur un écran pour les destinataires du tableau"
 }

--- a/src/main/resources/i18n/es.json
+++ b/src/main/resources/i18n/es.json
@@ -184,5 +184,6 @@
   "magneto.dropzone.overlay.warning": "Il est impossible d'importer un dossier",
   "magneto.dropzone.overlay.solution": "Veuillez importer un <b>fichier</b>",
   "magneto.dropzone.overlay.action": "J'ai compris",
-  "magneto.shared.push.notif.body": "shared a board with you"
+  "magneto.shared.push.notif.body": "shared a board with you",
+  "magneto.create.board.options.display.favorites": "Afficher le nombre de likes sur un écran pour les destinataires du tableau"
 }

--- a/src/main/resources/i18n/fr.json
+++ b/src/main/resources/i18n/fr.json
@@ -37,6 +37,7 @@
   "magneto.create.board.display.horizontal": "Section horizontale",
   "magneto.create.board.options": "Options du tableau",
   "magneto.create.board.options.comment": "Permettre aux utilisateurs de commenter les aimants",
+  "magneto.create.board.options.display.favorites": "Afficher le nombre de likes sur un écran pour les destinataires du tableau",
   "magneto.delete.section": "Supprimer la section",
   "magneto.delete.section.message": "Voulez-vous également supprimer les aimants contenus dans la section ? Si non, ils seront déplacés dans la première section.",
   "magneto.search.placeholder": "Rechercher ...",

--- a/src/main/resources/i18n/it.json
+++ b/src/main/resources/i18n/it.json
@@ -184,5 +184,6 @@
   "magneto.dropzone.overlay.warning": "Il est impossible d'importer un dossier",
   "magneto.dropzone.overlay.solution": "Veuillez importer un <b>fichier</b>",
   "magneto.dropzone.overlay.action": "J'ai compris",
-  "magneto.shared.push.notif.body": "shared a board with you"
+  "magneto.shared.push.notif.body": "shared a board with you",
+  "magneto.create.board.options.display.favorites": "Afficher le nombre de likes sur un écran pour les destinataires du tableau"
 }

--- a/src/main/resources/i18n/pt.json
+++ b/src/main/resources/i18n/pt.json
@@ -184,5 +184,6 @@
   "magneto.dropzone.overlay.warning": "Il est impossible d'importer un dossier",
   "magneto.dropzone.overlay.solution": "Veuillez importer un <b>fichier</b>",
   "magneto.dropzone.overlay.action": "J'ai compris",
-  "magneto.shared.push.notif.body": "shared a board with you"
+  "magneto.shared.push.notif.body": "shared a board with you",
+  "magneto.create.board.options.display.favorites": "Afficher le nombre de likes sur un écran pour les destinataires du tableau"
 }

--- a/src/main/resources/jsonschema/board.json
+++ b/src/main/resources/jsonschema/board.json
@@ -33,6 +33,9 @@
     "canComment": {
         "type": "boolean"
     },
+    "displayNbOfFavorites": {
+        "type": "boolean"
+    },
     "cardIds": {
       "type": "array",
       "items": {

--- a/src/main/resources/jsonschema/board.json
+++ b/src/main/resources/jsonschema/board.json
@@ -33,7 +33,7 @@
     "canComment": {
         "type": "boolean"
     },
-    "displayNbOfFavorites": {
+    "displayNbFavorites": {
         "type": "boolean"
     },
     "cardIds": {

--- a/src/main/resources/jsonschema/boardUpdate.json
+++ b/src/main/resources/jsonschema/boardUpdate.json
@@ -36,6 +36,9 @@
     "canComment": {
       "type": "boolean"
     },
+    "displayNbOfFavorites": {
+      "type": "boolean"
+    },
     "cardIds": {
       "type": "array",
       "items": {

--- a/src/main/resources/jsonschema/boardUpdate.json
+++ b/src/main/resources/jsonschema/boardUpdate.json
@@ -36,7 +36,7 @@
     "canComment": {
       "type": "boolean"
     },
-    "displayNbOfFavorites": {
+    "displayNbFavorites": {
       "type": "boolean"
     },
     "cardIds": {

--- a/src/main/resources/public/sass/global/components/directives/_board-manage-lightbox.scss
+++ b/src/main/resources/public/sass/global/components/directives/_board-manage-lightbox.scss
@@ -37,10 +37,12 @@
       &-options {
         display: flex;
         flex-direction: column;
-        margin-bottom: 32px;
-
+        margin-bottom: 0 !important;
         h2 {
           color: $magneto-black;
+        }
+        .checkbox{
+            margin-bottom: 10px;
         }
       }
 

--- a/src/main/resources/public/ts/controllers/__test__/board-read.controller.test.ts
+++ b/src/main/resources/public/ts/controllers/__test__/board-read.controller.test.ts
@@ -24,6 +24,7 @@ describe("BoardReadController", () => {
         _id: "id",
         backgroundUrl: "",
         canComment: false,
+        displayNbOfFavorites: false,
         cardIds: ["1", "2"],
         creationDate: "",
         deleted: false,

--- a/src/main/resources/public/ts/controllers/__test__/board-read.controller.test.ts
+++ b/src/main/resources/public/ts/controllers/__test__/board-read.controller.test.ts
@@ -24,7 +24,7 @@ describe("BoardReadController", () => {
         _id: "id",
         backgroundUrl: "",
         canComment: false,
-        displayNbOfFavorites: false,
+        displayNbFavorites: false,
         cardIds: ["1", "2"],
         creationDate: "",
         deleted: false,

--- a/src/main/resources/public/ts/directives/board-manage-lightbox/board-manage-lightbox.directive.ts
+++ b/src/main/resources/public/ts/directives/board-manage-lightbox/board-manage-lightbox.directive.ts
@@ -89,6 +89,7 @@ function directive($parse: IParseService) {
                     form.public = vm.form.public;
                     form.layoutType = vm.form.layoutType;
                     form.canComment = vm.form.canComment;
+                    form.displayNbOfFavorites = vm.form.displayNbOfFavorites;
 
                     if (vm.isUpdate) {
                         await boardsService.updateBoard(vm.form.id, form);

--- a/src/main/resources/public/ts/directives/board-manage-lightbox/board-manage-lightbox.directive.ts
+++ b/src/main/resources/public/ts/directives/board-manage-lightbox/board-manage-lightbox.directive.ts
@@ -89,7 +89,7 @@ function directive($parse: IParseService) {
                     form.public = vm.form.public;
                     form.layoutType = vm.form.layoutType;
                     form.canComment = vm.form.canComment;
-                    form.displayNbOfFavorites = vm.form.displayNbOfFavorites;
+                    form.displayNbFavorites = vm.form.displayNbFavorites;
 
                     if (vm.isUpdate) {
                         await boardsService.updateBoard(vm.form.id, form);

--- a/src/main/resources/public/ts/directives/board-manage-lightbox/board-manage-lightbox.html
+++ b/src/main/resources/public/ts/directives/board-manage-lightbox/board-manage-lightbox.html
@@ -32,13 +32,13 @@
                 <textarea ng-model="vm.form.description" class="twelve cell"></textarea>
             </div>
 
-            <div class="boardDirective-manage-lightbox-body-inputs-options" ng-if="vm.hasRight('comment')">
+            <div class="boardDirective-manage-lightbox-body-inputs-options" ng-if="vm.hasRight('comment') || vm.hasRight('favorites')">
                 <h2><i18n>magneto.create.board.options</i18n></h2>
-                <label class="checkbox">
+                <label class="checkbox" ng-if="vm.hasRight('comment')">
                     <input type="checkbox" ng-model="vm.form.canComment">
                     <span><i18n><span>magneto.create.board.options.comment</span></i18n></span>
                 </label>
-                <label class="checkbox">
+                <label class="checkbox" ng-if="vm.hasRight('favorites')">
                     <input type="checkbox" ng-model="vm.form.displayNbOfFavorites">
                     <span><i18n><span>magneto.create.board.options.display.favorites</span></i18n></span>
                 </label>

--- a/src/main/resources/public/ts/directives/board-manage-lightbox/board-manage-lightbox.html
+++ b/src/main/resources/public/ts/directives/board-manage-lightbox/board-manage-lightbox.html
@@ -38,6 +38,10 @@
                     <input type="checkbox" ng-model="vm.form.canComment">
                     <span><i18n><span>magneto.create.board.options.comment</span></i18n></span>
                 </label>
+                <label class="checkbox">
+                    <input type="checkbox" ng-model="vm.form.displayNbOfFavorites">
+                    <span><i18n><span>magneto.create.board.options.display.favorites</span></i18n></span>
+                </label>
             </div>
 
             <board-layout-type

--- a/src/main/resources/public/ts/directives/board-manage-lightbox/board-manage-lightbox.html
+++ b/src/main/resources/public/ts/directives/board-manage-lightbox/board-manage-lightbox.html
@@ -39,7 +39,7 @@
                     <span><i18n><span>magneto.create.board.options.comment</span></i18n></span>
                 </label>
                 <label class="checkbox" ng-if="vm.hasRight('favorites')">
-                    <input type="checkbox" ng-model="vm.form.displayNbOfFavorites">
+                    <input type="checkbox" ng-model="vm.form.displayNbFavorites">
                     <span><i18n><span>magneto.create.board.options.display.favorites</span></i18n></span>
                 </label>
             </div>

--- a/src/main/resources/public/ts/magnetoBehaviours.ts
+++ b/src/main/resources/public/ts/magnetoBehaviours.ts
@@ -17,6 +17,7 @@ export const rights = {
         view: 'fr.cgi.magneto.controller.MagnetoController|view',
         manage: 'fr.cgi.magneto.controller.BoardController|create',
         publish: 'fr.cgi.magneto.controller.FakeRight|boardPublish',
-        comment: 'fr.cgi.magneto.controller.FakeRight|boardComment'
+        comment: 'fr.cgi.magneto.controller.FakeRight|boardComment',
+        favorites: 'fr.cgi.magneto.controller.FakeRight|boardFavorites',
     }
 };

--- a/src/main/resources/public/ts/models/__test__/board.model.test.ts
+++ b/src/main/resources/public/ts/models/__test__/board.model.test.ts
@@ -23,7 +23,8 @@ describe('BoardModel', () => {
             tags: ['tag1', 'tag2'],
             public: false,
             deleted: false,
-            canComment: false
+            canComment: false,
+            displayNbOfFavorites: false
         }
 
         const board = new Board().build(boardResponse);
@@ -66,7 +67,8 @@ describe('BoardModel', () => {
                     tags: ['tag1', 'tag2'],
                     public: false,
                     deleted: false,
-                    canComment: false
+                    canComment: false,
+                    displayNbOfFavorites: false
                 }
             ],
             page: 1,
@@ -115,7 +117,8 @@ describe('BoardModel', () => {
             layoutType: LAYOUT_TYPE.FREE,
             imageUrl: 'imageUrl',
             backgroundUrl: 'backgroundUrl',
-            canComment: true
+            canComment: true,
+            displayNbOfFavorites: true
         }
 
         const formJSON2 = {
@@ -125,7 +128,8 @@ describe('BoardModel', () => {
             layoutType: LAYOUT_TYPE.FREE,
             imageUrl: 'imageUrl',
             backgroundUrl: 'backgroundUrl',
-            canComment: true
+            canComment: true,
+            displayNbOfFavorites: true
         }
 
         let form = new BoardForm();
@@ -134,6 +138,7 @@ describe('BoardModel', () => {
         form.imageUrl = 'imageUrl';
         form.backgroundUrl = 'backgroundUrl';
         form.canComment = true;
+        form.displayNbOfFavorites = true;
         expect(form.toJSON()).toEqual(formJSON1);
         form.id = 'id';
         expect(form.toJSON()).toEqual(formJSON2);

--- a/src/main/resources/public/ts/models/__test__/board.model.test.ts
+++ b/src/main/resources/public/ts/models/__test__/board.model.test.ts
@@ -24,7 +24,7 @@ describe('BoardModel', () => {
             public: false,
             deleted: false,
             canComment: false,
-            displayNbOfFavorites: false
+            displayNbFavorites: false
         }
 
         const board = new Board().build(boardResponse);
@@ -68,7 +68,7 @@ describe('BoardModel', () => {
                     public: false,
                     deleted: false,
                     canComment: false,
-                    displayNbOfFavorites: false
+                    displayNbFavorites: false
                 }
             ],
             page: 1,
@@ -118,7 +118,7 @@ describe('BoardModel', () => {
             imageUrl: 'imageUrl',
             backgroundUrl: 'backgroundUrl',
             canComment: true,
-            displayNbOfFavorites: true
+            displayNbFavorites: true
         }
 
         const formJSON2 = {
@@ -129,7 +129,7 @@ describe('BoardModel', () => {
             imageUrl: 'imageUrl',
             backgroundUrl: 'backgroundUrl',
             canComment: true,
-            displayNbOfFavorites: true
+            displayNbFavorites: true
         }
 
         let form = new BoardForm();
@@ -138,7 +138,7 @@ describe('BoardModel', () => {
         form.imageUrl = 'imageUrl';
         form.backgroundUrl = 'backgroundUrl';
         form.canComment = true;
-        form.displayNbOfFavorites = true;
+        form.displayNbFavorites = true;
         expect(form.toJSON()).toEqual(formJSON1);
         form.id = 'id';
         expect(form.toJSON()).toEqual(formJSON2);

--- a/src/main/resources/public/ts/models/board.model.ts
+++ b/src/main/resources/public/ts/models/board.model.ts
@@ -24,6 +24,7 @@ export interface IBoardItemResponse {
     ownerId: string;
     ownerName: string;
     canComment: boolean;
+    displayNbOfFavorites: boolean;
 }
 
 export interface IBoardsResponse {
@@ -55,6 +56,7 @@ export interface IBoardPayload {
     public?: boolean;
     layoutType?: LAYOUT_TYPE;
     canComment?: boolean;
+    displayNbOfFavorites?: boolean;
 }
 
 export interface ISection {
@@ -82,6 +84,7 @@ export class BoardForm {
     private _tagsTextInput: string;
     private _layoutType: LAYOUT_TYPE;
     private _canComment: boolean;
+    private _displayNbOfFavorites : boolean;
 
     constructor() {
         this._id = null;
@@ -97,6 +100,7 @@ export class BoardForm {
         this._layoutType = LAYOUT_TYPE.FREE;
         this._tagsTextInput = null;
         this._canComment = false;
+        this._displayNbOfFavorites = false;
     }
 
     build(board: Board): BoardForm {
@@ -111,6 +115,7 @@ export class BoardForm {
         this.public = board.public;
         this.layoutType = board.layoutType;
         this.canComment = board.canComment;
+        this.displayNbOfFavorites = board.displayNbOfFavorites;
         return this;
     }
 
@@ -219,6 +224,14 @@ export class BoardForm {
         this._canComment = value;
     }
 
+    get displayNbOfFavorites(): boolean {
+        return this._displayNbOfFavorites;
+    }
+
+    set displayNbOfFavorites(value: boolean) {
+        this._displayNbOfFavorites = value;
+    }
+
     isLayoutFree(): boolean {
         return this.layoutType == LAYOUT_TYPE.FREE;
     }
@@ -279,6 +292,10 @@ export class BoardForm {
             payload.id = this.id;
         }
 
+        if(this.displayNbOfFavorites != null) {
+            payload.displayNbOfFavorites = this.displayNbOfFavorites;
+        }
+
         return payload;
     }
 }
@@ -302,6 +319,7 @@ export class Board implements Shareable {
     private _public: boolean;
     private _deleted: boolean;
     private _canComment: boolean;
+    private _displayNbOfFavorites: boolean;
 
 
     // Share resource properties
@@ -335,6 +353,7 @@ export class Board implements Shareable {
         this.shared = data.shared;
         this._deleted = data.deleted;
         this._canComment = data.canComment;
+        this._displayNbOfFavorites = data.displayNbOfFavorites;
         return this;
     }
 
@@ -464,6 +483,14 @@ export class Board implements Shareable {
 
     set canComment(value: boolean) {
         this._canComment = value;
+    }
+
+    get displayNbOfFavorites(): boolean {
+        return this._displayNbOfFavorites;
+    }
+
+    set displayNbOfFavorites(value: boolean) {
+        this._displayNbOfFavorites = value;
     }
 }
 

--- a/src/main/resources/public/ts/models/board.model.ts
+++ b/src/main/resources/public/ts/models/board.model.ts
@@ -24,7 +24,7 @@ export interface IBoardItemResponse {
     ownerId: string;
     ownerName: string;
     canComment: boolean;
-    displayNbOfFavorites: boolean;
+    displayNbFavorites: boolean;
 }
 
 export interface IBoardsResponse {
@@ -56,7 +56,7 @@ export interface IBoardPayload {
     public?: boolean;
     layoutType?: LAYOUT_TYPE;
     canComment?: boolean;
-    displayNbOfFavorites?: boolean;
+    displayNbFavorites?: boolean;
 }
 
 export interface ISection {
@@ -84,7 +84,7 @@ export class BoardForm {
     private _tagsTextInput: string;
     private _layoutType: LAYOUT_TYPE;
     private _canComment: boolean;
-    private _displayNbOfFavorites : boolean;
+    private _displayNbFavorites : boolean;
 
     constructor() {
         this._id = null;
@@ -100,7 +100,7 @@ export class BoardForm {
         this._layoutType = LAYOUT_TYPE.FREE;
         this._tagsTextInput = null;
         this._canComment = false;
-        this._displayNbOfFavorites = false;
+        this._displayNbFavorites = false;
     }
 
     build(board: Board): BoardForm {
@@ -115,7 +115,7 @@ export class BoardForm {
         this.public = board.public;
         this.layoutType = board.layoutType;
         this.canComment = board.canComment;
-        this.displayNbOfFavorites = board.displayNbOfFavorites;
+        this.displayNbFavorites = board.displayNbFavorites;
         return this;
     }
 
@@ -224,12 +224,12 @@ export class BoardForm {
         this._canComment = value;
     }
 
-    get displayNbOfFavorites(): boolean {
-        return this._displayNbOfFavorites;
+    get displayNbFavorites(): boolean {
+        return this._displayNbFavorites;
     }
 
-    set displayNbOfFavorites(value: boolean) {
-        this._displayNbOfFavorites = value;
+    set displayNbFavorites(value: boolean) {
+        this._displayNbFavorites = value;
     }
 
     isLayoutFree(): boolean {
@@ -292,8 +292,8 @@ export class BoardForm {
             payload.id = this.id;
         }
 
-        if(this.displayNbOfFavorites != null) {
-            payload.displayNbOfFavorites = this.displayNbOfFavorites;
+        if(this.displayNbFavorites != null) {
+            payload.displayNbFavorites = this.displayNbFavorites;
         }
 
         return payload;
@@ -319,7 +319,7 @@ export class Board implements Shareable {
     private _public: boolean;
     private _deleted: boolean;
     private _canComment: boolean;
-    private _displayNbOfFavorites: boolean;
+    private _displayNbFavorites: boolean;
 
 
     // Share resource properties
@@ -353,7 +353,7 @@ export class Board implements Shareable {
         this.shared = data.shared;
         this._deleted = data.deleted;
         this._canComment = data.canComment;
-        this._displayNbOfFavorites = data.displayNbOfFavorites;
+        this._displayNbFavorites = data.displayNbFavorites;
         return this;
     }
 
@@ -485,12 +485,12 @@ export class Board implements Shareable {
         this._canComment = value;
     }
 
-    get displayNbOfFavorites(): boolean {
-        return this._displayNbOfFavorites;
+    get displayNbFavorites(): boolean {
+        return this._displayNbFavorites;
     }
 
-    set displayNbOfFavorites(value: boolean) {
-        this._displayNbOfFavorites = value;
+    set displayNbFavorites(value: boolean) {
+        this._displayNbFavorites = value;
     }
 }
 

--- a/src/test/java/fr/cgi/magneto/service/BoardServiceTest.java
+++ b/src/test/java/fr/cgi/magneto/service/BoardServiceTest.java
@@ -130,6 +130,7 @@ public class BoardServiceTest {
                "            \"imageUrl\":1,\n" +
                "            \"backgroundUrl\":1,\n" +
                "            \"canComment\":1,\n" +
+               "            \"displayNbOfFavorites\":1,\n" +
                "            \"nbCards\":1,\n" +
                "            \"nbCardsSections\":1,\n" +
                "            \"modificationDate\":1,\n" +

--- a/src/test/java/fr/cgi/magneto/service/BoardServiceTest.java
+++ b/src/test/java/fr/cgi/magneto/service/BoardServiceTest.java
@@ -130,7 +130,7 @@ public class BoardServiceTest {
                "            \"imageUrl\":1,\n" +
                "            \"backgroundUrl\":1,\n" +
                "            \"canComment\":1,\n" +
-               "            \"displayNbOfFavorites\":1,\n" +
+               "            \"displayNbFavorites\":1,\n" +
                "            \"nbCards\":1,\n" +
                "            \"nbCardsSections\":1,\n" +
                "            \"modificationDate\":1,\n" +


### PR DESCRIPTION
## Describe your changes
Added an option in board properties to display the number of favorites of a cards or not.
Also adde da workflow Right related to that "magneto.board.favorites"
## Checklist tests
Without the workflow right  "magneto.board.favorites", create a board, the checkbox for this option should not be displayed.

Then with the right create a board and check if the checkbox is here. If its here check it, then go to the board properties and verify if its still checked.
## Issue ticket number and link
[MAG-218](https://jira.support-ent.fr/browse/MAG-218)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

