### PR TITLE
feat(boardView): #MAG-213 add lightbox to display long description

### DIFF
--- a/src/main/resources/i18n/de.json
+++ b/src/main/resources/i18n/de.json
@@ -65,6 +65,7 @@
   "magneto.board.unpublish.title": "Delete share of board from the platform",
   "magneto.board.publish.description": "When sharing this board to the platform, it will be visible in read-only to all users of the platform. The board magnets can be reused.",
   "magneto.board.unpublish.description": "Do you want to remove the sharing of the board from the platform ?",
+  "magneto.board.description": "Description",
   "magneto.duplicate": "Duplicate",
   "magneto.restore": "Restore",
   "magneto.move": "Move",

--- a/src/main/resources/i18n/de.json
+++ b/src/main/resources/i18n/de.json
@@ -66,6 +66,7 @@
   "magneto.board.publish.description": "When sharing this board to the platform, it will be visible in read-only to all users of the platform. The board magnets can be reused.",
   "magneto.board.unpublish.description": "Do you want to remove the sharing of the board from the platform ?",
   "magneto.board.description": "Description",
+  "magneto.board.description.readmore": "Lire plus",
   "magneto.duplicate": "Duplicate",
   "magneto.restore": "Restore",
   "magneto.move": "Move",

--- a/src/main/resources/i18n/en.json
+++ b/src/main/resources/i18n/en.json
@@ -65,6 +65,7 @@
   "magneto.board.unpublish.title": "Delete share of board from the platform",
   "magneto.board.publish.description": "When sharing this board to the platform, it will be visible in read-only to all users of the platform. The board magnets can be reused.",
   "magneto.board.unpublish.description": "Do you want to remove the sharing of the board from the platform ?",
+  "magneto.board.description": "Description",
   "magneto.duplicate": "Duplicate",
   "magneto.restore": "Restore",
   "magneto.move": "Move",

--- a/src/main/resources/i18n/en.json
+++ b/src/main/resources/i18n/en.json
@@ -66,6 +66,7 @@
   "magneto.board.publish.description": "When sharing this board to the platform, it will be visible in read-only to all users of the platform. The board magnets can be reused.",
   "magneto.board.unpublish.description": "Do you want to remove the sharing of the board from the platform ?",
   "magneto.board.description": "Description",
+  "magneto.board.description.readmore": "Lire plus",
   "magneto.duplicate": "Duplicate",
   "magneto.restore": "Restore",
   "magneto.move": "Move",

--- a/src/main/resources/i18n/es.json
+++ b/src/main/resources/i18n/es.json
@@ -65,6 +65,7 @@
   "magneto.board.unpublish.title": "Delete share of board from the platform",
   "magneto.board.publish.description": "When sharing this board to the platform, it will be visible in read-only to all users of the platform. The board magnets can be reused.",
   "magneto.board.unpublish.description": "Do you want to remove the sharing of the board from the platform ?",
+  "magneto.board.description": "Description",
   "magneto.duplicate": "Duplicate",
   "magneto.restore": "Restore",
   "magneto.move": "Move",

--- a/src/main/resources/i18n/es.json
+++ b/src/main/resources/i18n/es.json
@@ -66,6 +66,7 @@
   "magneto.board.publish.description": "When sharing this board to the platform, it will be visible in read-only to all users of the platform. The board magnets can be reused.",
   "magneto.board.unpublish.description": "Do you want to remove the sharing of the board from the platform ?",
   "magneto.board.description": "Description",
+  "magneto.board.description.readmore": "Lire plus",
   "magneto.duplicate": "Duplicate",
   "magneto.restore": "Restore",
   "magneto.move": "Move",

--- a/src/main/resources/i18n/fr.json
+++ b/src/main/resources/i18n/fr.json
@@ -66,6 +66,7 @@
   "magneto.board.publish.description": "En partageant ce tableau à toute la plateforme, il sera accessible pour tous les utilisateurs de la plateforme en lecture et ses aimants pourront être réutilisés.",
   "magneto.board.unpublish.description": "Voulez-vous supprimer le partage du tableau de la plateforme ?",
   "magneto.board.description": "Description",
+  "magneto.board.description.readmore": "Lire plus",
   "magneto.duplicate": "Dupliquer",
   "magneto.restore": "Restaurer",
   "magneto.move": "Déplacer",

--- a/src/main/resources/i18n/fr.json
+++ b/src/main/resources/i18n/fr.json
@@ -65,6 +65,7 @@
   "magneto.board.unpublish.title": "Supprimer le partage du tableau de la plateforme",
   "magneto.board.publish.description": "En partageant ce tableau à toute la plateforme, il sera accessible pour tous les utilisateurs de la plateforme en lecture et ses aimants pourront être réutilisés.",
   "magneto.board.unpublish.description": "Voulez-vous supprimer le partage du tableau de la plateforme ?",
+  "magneto.board.description": "Description",
   "magneto.duplicate": "Dupliquer",
   "magneto.restore": "Restaurer",
   "magneto.move": "Déplacer",

--- a/src/main/resources/i18n/it.json
+++ b/src/main/resources/i18n/it.json
@@ -65,6 +65,7 @@
   "magneto.board.unpublish.title": "Delete share of board from the platform",
   "magneto.board.publish.description": "When sharing this board to the platform, it will be visible in read-only to all users of the platform. The board magnets can be reused.",
   "magneto.board.unpublish.description": "Do you want to remove the sharing of the board from the platform ?",
+  "magneto.board.description": "Description",
   "magneto.duplicate": "Duplicate",
   "magneto.restore": "Restore",
   "magneto.move": "Move",

--- a/src/main/resources/i18n/it.json
+++ b/src/main/resources/i18n/it.json
@@ -66,6 +66,7 @@
   "magneto.board.publish.description": "When sharing this board to the platform, it will be visible in read-only to all users of the platform. The board magnets can be reused.",
   "magneto.board.unpublish.description": "Do you want to remove the sharing of the board from the platform ?",
   "magneto.board.description": "Description",
+  "magneto.board.description.readmore": "Lire plus",
   "magneto.duplicate": "Duplicate",
   "magneto.restore": "Restore",
   "magneto.move": "Move",

--- a/src/main/resources/i18n/pt.json
+++ b/src/main/resources/i18n/pt.json
@@ -65,6 +65,7 @@
   "magneto.board.unpublish.title": "Delete share of board from the platform",
   "magneto.board.publish.description": "When sharing this board to the platform, it will be visible in read-only to all users of the platform. The board magnets can be reused.",
   "magneto.board.unpublish.description": "Do you want to remove the sharing of the board from the platform ?",
+  "magneto.board.description": "Description",
   "magneto.duplicate": "Duplicate",
   "magneto.restore": "Restore",
   "magneto.move": "Move",

--- a/src/main/resources/i18n/pt.json
+++ b/src/main/resources/i18n/pt.json
@@ -66,6 +66,7 @@
   "magneto.board.publish.description": "When sharing this board to the platform, it will be visible in read-only to all users of the platform. The board magnets can be reused.",
   "magneto.board.unpublish.description": "Do you want to remove the sharing of the board from the platform ?",
   "magneto.board.description": "Description",
+  "magneto.board.description.readmore": "Lire plus",
   "magneto.duplicate": "Duplicate",
   "magneto.restore": "Restore",
   "magneto.move": "Move",

--- a/src/main/resources/public/sass/global/_mixins.scss
+++ b/src/main/resources/public/sass/global/_mixins.scss
@@ -117,6 +117,7 @@ $spacing-XXL: 68px;
 $spacing-XML: 60px;
 $spacing-XM: 48px;
 $spacing-XL: 42px;
+$spacing-LL: 30px;
 $spacing-L: 24px;
 $spacing-M: 16px;
 $spacing-S: 12px;

--- a/src/main/resources/public/sass/global/components/containers/_board.scss
+++ b/src/main/resources/public/sass/global/components/containers/_board.scss
@@ -23,13 +23,13 @@
     }
 
     &-degrade {
-      background: linear-gradient(to top, #FFFFFF 15%,transparent);
+      background: linear-gradient(to top, #FFFFFF 0.9%,transparent);
       position: absolute;
-      height: 80%;
+      height: 43%;
     }
 
     &-description {
-      max-height: 64px !important;
+      max-height: 66px !important;
       overflow: hidden !important;
       white-space: pre-line !important;
       margin-bottom: 5px !important;
@@ -38,7 +38,7 @@
 
   &-header-mobile {
     background: $magneto-white;
-    padding: $spacing-LXS $spacing-LXS $spacing-LXS 73px;
+    padding: $spacing-LXS $spacing-LXS $spacing-LL 73px;
     top: -12px;
     z-index: unset;
     @include noTextOverflow(1);
@@ -83,7 +83,7 @@
     position: absolute;
 
     @include mobile {
-      top: 65px;
+      top: 88px;
     }
 
     &-nav {

--- a/src/main/resources/public/sass/global/components/containers/_board.scss
+++ b/src/main/resources/public/sass/global/components/containers/_board.scss
@@ -22,10 +22,17 @@
       margin-top: 5px;
     }
 
+    &-degrade {
+      background: linear-gradient(to top, #FFFFFF 15%,transparent);
+      position: absolute;
+      height: 80%;
+    }
+
     &-description {
-      max-height: 64px;
-      overflow: hidden;
-      white-space: pre-line;
+      max-height: 64px !important;
+      overflow: hidden !important;
+      white-space: pre-line !important;
+      margin-bottom: 5px !important;
     }
   }
 
@@ -54,8 +61,9 @@
     }
 
     &-description {
-      height: 64px;
-      overflow-y: auto;
+      overflow: hidden !important;
+      white-space: pre-line !important;
+      height: 28px !important;
     }
 
     .create-button {

--- a/src/main/resources/public/sass/global/components/containers/_board.scss
+++ b/src/main/resources/public/sass/global/components/containers/_board.scss
@@ -23,8 +23,8 @@
     }
 
     &-description {
-      height: 64px;
-      overflow-y: auto;
+      max-height: 64px;
+      overflow: hidden;
       white-space: pre-line;
     }
   }

--- a/src/main/resources/public/sass/global/components/directives/_board-description-lightbox.scss
+++ b/src/main/resources/public/sass/global/components/directives/_board-description-lightbox.scss
@@ -1,0 +1,37 @@
+.board-description-lightbox {
+  overflow: unset !important;
+
+  &-content {
+    @include lightboxWidth(70%);
+    display: flex;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    padding: 1px 15px !important;
+
+    &-head {
+
+    }
+
+    &-body {
+      margin-top: -2em !important;
+      white-space: pre-line !important;
+
+      &-inputs {
+      }
+    }
+  }
+
+  &-read-more-link {
+    position: relative !important;
+    z-index: 10 !important;
+  }
+
+  scrollbar-lightbox {
+    overflow-y: auto;
+  }
+
+  no-scroll {
+    overflow-y: hidden;
+  }
+}

--- a/src/main/resources/public/sass/global/components/directives/_board-description-lightbox.scss
+++ b/src/main/resources/public/sass/global/components/directives/_board-description-lightbox.scss
@@ -23,8 +23,7 @@
   }
 
   &-read-more-link {
-    position: relative !important;
-    z-index: 10 !important;
+
   }
 
   scrollbar-lightbox {

--- a/src/main/resources/public/sass/global/components/directives/_board-description-lightbox.scss
+++ b/src/main/resources/public/sass/global/components/directives/_board-description-lightbox.scss
@@ -1,4 +1,4 @@
-.board-description-lightbox {
+.boardDirective-description-lightbox {
   overflow: unset !important;
 
   &-content {

--- a/src/main/resources/public/sass/global/components/directives/_index.scss
+++ b/src/main/resources/public/sass/global/components/directives/_index.scss
@@ -21,3 +21,4 @@
 @import 'card-item-comments';
 @import 'card-comment';
 @import 'comments-panel';
+@import 'board-description-lightbox';

--- a/src/main/resources/public/template/board.html
+++ b/src/main/resources/public/template/board.html
@@ -17,9 +17,13 @@
                 <board-date date="vm.board.modificationDate"></board-date>
             </div>
         </div>
-        <div ng-if="!!vm.board.description" class="board-container-header-description" ng-bind="vm.board.description"></div>
+        <div class="board-container-header-desc">
+            <div ng-if="!!vm.board.description" class="board-container-header-description twelve cell"><span id="description">[[vm.board.description]]</span></div>
+            <div class="board-container-header-degrade twelve" ng-if="vm.showReadMoreLink"></div>
+        </div>
         <board-description-lightbox
-                                board="vm.board"
+                board="vm.board"
+                show-read-more-link="vm.showReadMoreLink"
         >
         </board-description-lightbox>
     </div>
@@ -43,9 +47,7 @@
             </button>
 
         </div>
-        <div ng-if="!!vm.board.description" class="board-container-header-description">
-            <p class="board-container-header-description-text" ng-bind="vm.board.description"></p>
-        </div>
+        <div ng-if="!!vm.board.description" class="board-container-header-mobile-description"><span id="description-mobile">[[vm.board.description]]</span></div>
         <board-description-lightbox
                 board="vm.board"
         >

--- a/src/main/resources/public/template/board.html
+++ b/src/main/resources/public/template/board.html
@@ -43,7 +43,13 @@
             </button>
 
         </div>
-        <div ng-if="!!vm.board.description" class="board-container-header-description" ng-bind="vm.board.description"></div>
+        <div ng-if="!!vm.board.description" class="board-container-header-description">
+            <p class="board-container-header-description-text" ng-bind="vm.board.description"></p>
+        </div>
+        <board-description-lightbox
+                board="vm.board"
+        >
+        </board-description-lightbox>
     </div>
 
     <div class="twelve cell board-container-body"

--- a/src/main/resources/public/template/board.html
+++ b/src/main/resources/public/template/board.html
@@ -50,6 +50,7 @@
         <div ng-if="!!vm.board.description" class="board-container-header-mobile-description"><span id="description-mobile">[[vm.board.description]]</span></div>
         <board-description-lightbox
                 board="vm.board"
+                show-read-more-link="vm.showReadMoreLink"
         >
         </board-description-lightbox>
     </div>

--- a/src/main/resources/public/template/board.html
+++ b/src/main/resources/public/template/board.html
@@ -18,6 +18,10 @@
             </div>
         </div>
         <div ng-if="!!vm.board.description" class="board-container-header-description" ng-bind="vm.board.description"></div>
+        <board-description-lightbox
+                                board="vm.board"
+        >
+        </board-description-lightbox>
     </div>
 
     <!-- Header mobile -->

--- a/src/main/resources/public/ts/controllers/board-view.controller.ts
+++ b/src/main/resources/public/ts/controllers/board-view.controller.ts
@@ -67,6 +67,8 @@ interface IViewModel extends ng.IController {
     infiniteScrollService: InfiniteScrollService;
     cardUpdateSubject: Subject<void>;
 
+    showReadMoreLink: boolean;
+
     goToBoards(): void;
 
     getCards(): Promise<void>;
@@ -151,6 +153,7 @@ class Controller implements IViewModel {
     infiniteScrollService: InfiniteScrollService;
 
     cardUpdateSubject: Subject<void>;
+    showReadMoreLink: boolean;
 
     constructor(private $scope: IBoardViewScope,
                 private $route: any,
@@ -195,6 +198,7 @@ class Controller implements IViewModel {
         this.isLoading = true;
         this.isDraggable = true;
         this.nestedSortables = [];
+        this.showReadMoreLink = false;
         this.initDraggable();
 
 

--- a/src/main/resources/public/ts/directives/board-description-lightbox/board-description-lightbox.directive.ts
+++ b/src/main/resources/public/ts/directives/board-description-lightbox/board-description-lightbox.directive.ts
@@ -55,7 +55,7 @@ class Controller implements IViewModel {
 
 }
 
-function directive() {
+function directive($timeout: ng.ITimeoutService): ng.IDirective {
     return {
         restrict: 'E',
         templateUrl: `${RootsConst.directive}board-description-lightbox/board-description-lightbox.html`,
@@ -65,7 +65,7 @@ function directive() {
         },
         controllerAs: 'vm',
         bindToController: true,
-        controller: ['$scope', Controller],
+        controller: ['$scope', '$timeout', Controller],
         /* interaction DOM/element */
         link: function ($scope: IBoardDescriptionScope,
                         element: ng.IAugmentedJQuery,
@@ -74,7 +74,12 @@ function directive() {
             const descriptionHeightLimit : number = 64;
             const descriptionHeightLimitMobile : number = 28;
 
-            $(document).ready($scope.vm.checkDescriptionSize);
+            $(document).ready(() => {
+                $timeout(() => {
+                    vm.checkDescriptionSize()
+                }, 100);
+            });
+
             $scope.vm.checkDescriptionSize = (): void => {
                 let windowElement : JQuery = $(window);
                 if (windowElement.width() < 768) {
@@ -90,7 +95,6 @@ function directive() {
                     vm.updateSetVisible(spanHeight >= descriptionHeightLimit);
                 }
             }
-
             $scope.$watch('vm.board.description', () => {
                 $scope.vm.checkDescriptionSize();
             });

--- a/src/main/resources/public/ts/directives/board-description-lightbox/board-description-lightbox.directive.ts
+++ b/src/main/resources/public/ts/directives/board-description-lightbox/board-description-lightbox.directive.ts
@@ -84,14 +84,14 @@ function directive($timeout: ng.ITimeoutService): ng.IDirective {
                 let windowElement : JQuery = $(window);
                 if (windowElement.width() < 768) {
                     let descriptionElement : HTMLElement = angular.element('.board-container-header-mobile-description');
-                    let spanElement = descriptionElement[0].querySelector('span');
-                    let spanHeight = spanElement.offsetHeight;
+                    let spanElement : HTMLElement = descriptionElement[0].querySelector('span');
+                    let spanHeight : number = spanElement.offsetHeight;
                     vm.updateSetVisible(spanHeight >= descriptionHeightLimitMobile);
                 }
                 if (windowElement.width() > 768){
                     let descriptionElement : HTMLElement = angular.element('.board-container-header-description');
-                    let spanElement = descriptionElement[0].querySelector('span');
-                    let spanHeight = spanElement.offsetHeight;
+                    let spanElement : HTMLElement = descriptionElement[0].querySelector('span');
+                    let spanHeight : number = spanElement.offsetHeight;
                     vm.updateSetVisible(spanHeight >= descriptionHeightLimit);
                 }
             }

--- a/src/main/resources/public/ts/directives/board-description-lightbox/board-description-lightbox.directive.ts
+++ b/src/main/resources/public/ts/directives/board-description-lightbox/board-description-lightbox.directive.ts
@@ -1,0 +1,65 @@
+import {ng} from "entcore";
+import {ILocationService, IScope, IWindowService} from "angular";
+import {RootsConst} from "../../core/constants/roots.const";
+import {Board, Boards, Card, IBoardOwner, IBoardPayload, IBoardsParamsRequest} from "../../models";
+import {IBoardsService} from "../../services";
+
+interface IViewModel extends ng.IController, IBoardDescriptionProps {
+    display(): void;
+    closeForm(): void;
+}
+
+interface IBoardDescriptionProps {
+
+}
+
+interface IBoardDescriptionScope extends IScope, IBoardDescriptionProps {
+    vm: IViewModel;
+}
+
+class Controller implements IViewModel {
+
+    displayDescription : boolean = false;
+    boards: Array<Board>;
+
+
+    constructor(private $scope: IBoardDescriptionScope) {
+    }
+
+    $onInit() {
+    }
+
+    display = (): void => {
+        this.displayDescription = true;
+    }
+
+    closeForm = (): void => {
+        this.displayDescription = false;
+    }
+
+    $onDestroy() {
+    }
+
+}
+
+function directive() {
+    return {
+        restrict: 'E',
+        templateUrl: `${RootsConst.directive}board-description-lightbox/board-description-lightbox.html`,
+        scope: {
+            board: '=',
+        },
+        controllerAs: 'vm',
+        bindToController: true,
+        controller: ['$scope', Controller],
+        /* interaction DOM/element */
+        link: function ($scope: IBoardDescriptionScope,
+                        element: ng.IAugmentedJQuery,
+                        attrs: ng.IAttributes,
+                        vm: IViewModel) {
+
+        }
+    }
+}
+
+export const boardDescriptionLightbox = ng.directive('boardDescriptionLightbox', directive)

--- a/src/main/resources/public/ts/directives/board-description-lightbox/board-description-lightbox.directive.ts
+++ b/src/main/resources/public/ts/directives/board-description-lightbox/board-description-lightbox.directive.ts
@@ -76,13 +76,14 @@ function directive() {
 
             $(document).ready($scope.vm.checkDescriptionSize);
             $scope.vm.checkDescriptionSize = (): void => {
-                if ($("#description-mobile").length > 0) {
+                let windowElement : JQuery = $(window);
+                if (windowElement.width() < 768) {
                     let descriptionElement : HTMLElement = angular.element('.board-container-header-mobile-description');
                     let spanElement = descriptionElement[0].querySelector('span');
                     let spanHeight = spanElement.offsetHeight;
                     vm.updateSetVisible(spanHeight >= descriptionHeightLimitMobile);
                 }
-                if ($("#description").length > 0){
+                if (windowElement.width() > 768){
                     let descriptionElement : HTMLElement = angular.element('.board-container-header-description');
                     let spanElement = descriptionElement[0].querySelector('span');
                     let spanHeight = spanElement.offsetHeight;

--- a/src/main/resources/public/ts/directives/board-description-lightbox/board-description-lightbox.directive.ts
+++ b/src/main/resources/public/ts/directives/board-description-lightbox/board-description-lightbox.directive.ts
@@ -1,4 +1,4 @@
-import {ng} from "entcore";
+import {angular, ng} from "entcore";
 import {ILocationService, IScope, IWindowService} from "angular";
 import {RootsConst} from "../../core/constants/roots.const";
 import {Board, Boards, Card, IBoardOwner, IBoardPayload, IBoardsParamsRequest} from "../../models";
@@ -14,12 +14,14 @@ interface IBoardDescriptionProps {
 }
 
 interface IBoardDescriptionScope extends IScope, IBoardDescriptionProps {
+    checkDescriptionSize: () => void;
     vm: IViewModel;
 }
 
 class Controller implements IViewModel {
 
     displayDescription : boolean = false;
+    showReadMoreLink: boolean = false;
     boards: Array<Board>;
 
 
@@ -58,6 +60,14 @@ function directive() {
                         attrs: ng.IAttributes,
                         vm: IViewModel) {
 
+            $scope.checkDescriptionSize = (): void => {
+                let descriptionElement = angular.element('.board-container-header-description-text');
+                let descriptionHeight = descriptionElement[0].offsetHeight;
+                this.showReadMoreLink = descriptionHeight > 64;
+            }
+            $scope.$watch('vm.board.description', () => {
+                $scope.checkDescriptionSize();
+            });
         }
     }
 }

--- a/src/main/resources/public/ts/directives/board-description-lightbox/board-description-lightbox.html
+++ b/src/main/resources/public/ts/directives/board-description-lightbox/board-description-lightbox.html
@@ -24,8 +24,8 @@
             </button>
         </div>-->
     </lightbox>
-    <button ng-click="vm.display()">
-        Lire plus
-    </button>
+    <strong class="read-more-link" ng-if="vm.showReadMoreLink">
+        <a ng-click="vm.display()">Lire plus</a>
+    </strong>
 </div>
 

--- a/src/main/resources/public/ts/directives/board-description-lightbox/board-description-lightbox.html
+++ b/src/main/resources/public/ts/directives/board-description-lightbox/board-description-lightbox.html
@@ -1,20 +1,20 @@
-<div class="board-description-lightbox scrollbar">
+<div class="boardDirective-description-lightbox scrollbar">
     <lightbox
             show="vm.displayDescription"
             on-close="vm.displayDescription = false"
-            class="board-description-lightbox-content no-scroll">
-        <section class="head board-description-lightbox-content-head">
+            class="boardDirective-description-lightbox-content no-scroll">
+        <section class="head boardDirective-description-lightbox-content-head">
             <h3>
                 <i18n>magneto.title</i18n>
                 / [[vm.board.title]]
             </h3>
         </section>
-        <section class="body board-description-lightbox-content-body">
+        <section class="body boardDirective-description-lightbox-content-body">
             <h4><i18n>magneto.board.description</i18n></h4>
-            <div class="board-description-lightbox-content-body-inputs scrollbar-lightbox" ng-bind="vm.board.description"></div>
+            <div class="boardDirective-description-lightbox-content-body-inputs scrollbar-lightbox" ng-bind="vm.board.description"></div>
         </section>
     </lightbox>
-    <strong class="board-description-lightbox-read-more-link" ng-if="vm.showReadMoreLink">
+    <strong class="boardDirective-description-lightbox-read-more-link" ng-if="vm.showReadMoreLink">
         <a ng-click="vm.display()">
             <i18n>magneto.board.description.readmore</i18n>
         </a>

--- a/src/main/resources/public/ts/directives/board-description-lightbox/board-description-lightbox.html
+++ b/src/main/resources/public/ts/directives/board-description-lightbox/board-description-lightbox.html
@@ -1,31 +1,23 @@
-<div>
+<div class="board-description-lightbox scrollbar">
     <lightbox
             show="vm.displayDescription"
             on-close="vm.displayDescription = false"
-            class="board-description-lightbox">
-        <section class="head board-description-lightbox-head">
+            class="board-description-lightbox-content no-scroll">
+        <section class="head board-description-lightbox-content-head">
             <h3>
                 <i18n>magneto.title</i18n>
                 / [[vm.board.title]]
             </h3>
         </section>
-
-        <section class="body board-description-lightbox-body">
-            <h4>
-                <i18n>magneto.board.description</i18n>
-            </h4>
-            <div class="row vertical-spacing board-description-lightbox-body-inputs" ng-bind="vm.board.description">
-                <!-- Description du tableau -->
-            </div>
+        <section class="body board-description-lightbox-content-body">
+            <h4><i18n>magneto.board.description</i18n></h4>
+            <div class="board-description-lightbox-content-body-inputs scrollbar-lightbox" ng-bind="vm.board.description"></div>
         </section>
-        <!--<div class="twelve cell">
-            <button class="right-magnet cancel" ng-click="vm.closeForm()">
-                <i18n>magneto.cancel</i18n>
-            </button>
-        </div>-->
     </lightbox>
-    <strong class="read-more-link" ng-if="vm.showReadMoreLink">
-        <a ng-click="vm.display()">Lire plus</a>
+    <strong class="board-description-lightbox-read-more-link" ng-if="vm.showReadMoreLink">
+        <a ng-click="vm.display()">
+            <i18n>magneto.board.description.readmore</i18n>
+        </a>
     </strong>
 </div>
 

--- a/src/main/resources/public/ts/directives/board-description-lightbox/board-description-lightbox.html
+++ b/src/main/resources/public/ts/directives/board-description-lightbox/board-description-lightbox.html
@@ -1,0 +1,31 @@
+<div>
+    <lightbox
+            show="vm.displayDescription"
+            on-close="vm.displayDescription = false"
+            class="board-description-lightbox">
+        <section class="head board-description-lightbox-head">
+            <h3>
+                <i18n>magneto.title</i18n>
+                / [[vm.board.title]]
+            </h3>
+        </section>
+
+        <section class="body board-description-lightbox-body">
+            <h4>
+                <i18n>magneto.board.description</i18n>
+            </h4>
+            <div class="row vertical-spacing board-description-lightbox-body-inputs" ng-bind="vm.board.description">
+                <!-- Description du tableau -->
+            </div>
+        </section>
+        <!--<div class="twelve cell">
+            <button class="right-magnet cancel" ng-click="vm.closeForm()">
+                <i18n>magneto.cancel</i18n>
+            </button>
+        </div>-->
+    </lightbox>
+    <button ng-click="vm.display()">
+        Lire plus
+    </button>
+</div>
+

--- a/src/main/resources/public/ts/directives/index.ts
+++ b/src/main/resources/public/ts/directives/index.ts
@@ -46,3 +46,4 @@ export * from './card-comment/card-comment.directive';
 export * from './comments-panel/comments-panel.directive';
 export * from './comment-input/comment-input.directive';
 export * from './comment-delete-lightbox/comment-delete-lightbox.directive';
+export * from './board-description-lightbox/board-description-lightbox.directive';


### PR DESCRIPTION
## Describe your changes
When a board description is longer than 3 lines, "Read more" appear, on click open popup to display description in full length.

## Checklist tests
Go to "Magento" --> open a board --> add a description, test a small description (nothing append), then a long one ("Read more" appear), click on it and you should see a popup with the description.

## Issue ticket number and link
[MAG-213](https://jira.support-ent.fr/browse/MAG-213)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

