### PR TITLE
feat(boardView): #MAG-213 add lightbox to display long description #17

### DIFF
--- a/src/main/resources/public/template/board.html
+++ b/src/main/resources/public/template/board.html
@@ -17,7 +17,6 @@
                 <board-date date="vm.board.modificationDate"></board-date>
             </div>
         </div>
-        <div ng-if="!!vm.board.description" class="boardContainer-container-header-description" ng-bind="vm.board.description"></div>
         <div class="board-container-header-desc">
             <div ng-if="!!vm.board.description" class="boardContainer-container-header-description twelve cell"><span id="description">[[vm.board.description]]</span></div>
             <div class="board-container-header-degrade twelve" ng-if="vm.showReadMoreLink"></div>
@@ -48,7 +47,6 @@
             </button>
 
         </div>
-        <div ng-if="!!vm.board.description" class="boardContainer-container-header-description" ng-bind="vm.board.description"></div>
         <div ng-if="!!vm.board.description" class="boardContainer-container-header-mobile-description"><span id="description-mobile">[[vm.board.description]]</span></div>
         <board-description-lightbox
                 board="vm.board"

--- a/src/main/resources/public/template/board.html
+++ b/src/main/resources/public/template/board.html
@@ -17,9 +17,9 @@
                 <board-date date="vm.board.modificationDate"></board-date>
             </div>
         </div>
-        <div class="board-container-header-desc">
+        <div class="boardContainer-container-header-desc">
             <div ng-if="!!vm.board.description" class="boardContainer-container-header-description twelve cell"><span id="description">[[vm.board.description]]</span></div>
-            <div class="board-container-header-degrade twelve" ng-if="vm.showReadMoreLink"></div>
+            <div class="boardContainer-container-header-degrade twelve" ng-if="vm.showReadMoreLink"></div>
         </div>
         <board-description-lightbox
                 board="vm.board"

--- a/src/main/resources/public/ts/directives/board-description-lightbox/board-description-lightbox.directive.ts
+++ b/src/main/resources/public/ts/directives/board-description-lightbox/board-description-lightbox.directive.ts
@@ -71,7 +71,7 @@ function directive($timeout: ng.ITimeoutService): ng.IDirective {
                         element: ng.IAugmentedJQuery,
                         attrs: ng.IAttributes,
                         vm: IViewModel) {
-            const descriptionHeightLimit : number = 64;
+            const descriptionHeightLimit : number = 66;
             const descriptionHeightLimitMobile : number = 28;
 
             $(document).ready(() => {

--- a/src/main/resources/public/ts/directives/board-description-lightbox/board-description-lightbox.directive.ts
+++ b/src/main/resources/public/ts/directives/board-description-lightbox/board-description-lightbox.directive.ts
@@ -83,13 +83,13 @@ function directive($timeout: ng.ITimeoutService): ng.IDirective {
             $scope.vm.checkDescriptionSize = (): void => {
                 let windowElement : JQuery = $(window);
                 if (windowElement.width() < 768) {
-                    let descriptionElement : HTMLElement = angular.element('.board-container-header-mobile-description');
+                    let descriptionElement : HTMLElement = angular.element('.boardContainer-container-header-mobile-description');
                     let spanElement : HTMLElement = descriptionElement[0].querySelector('span');
                     let spanHeight : number = spanElement.offsetHeight;
                     vm.updateSetVisible(spanHeight >= descriptionHeightLimitMobile);
                 }
                 if (windowElement.width() > 768){
-                    let descriptionElement : HTMLElement = angular.element('.board-container-header-description');
+                    let descriptionElement : HTMLElement = angular.element('.boardContainer-container-header-description');
                     let spanElement : HTMLElement = descriptionElement[0].querySelector('span');
                     let spanHeight : number = spanElement.offsetHeight;
                     vm.updateSetVisible(spanHeight >= descriptionHeightLimit);


### PR DESCRIPTION
## Describe your changes
When a board description is longer than 3 lines, "Read more" appear, on click open popup to display description in full length.

## Checklist tests
Go to "Magento" --> open a board --> add a description, test a small description (nothing append), then a long one ("Read more" appear), click on it and you should see a popup with the description.

## Issue ticket number and link
[MAG-213](https://jira.support-ent.fr/browse/MAG-213)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

