### PR TITLE
fix(css): #MAG-226 fix missing z-index for cards options

### DIFF
--- a/src/main/resources/public/sass/global/components/directives/_card-list-item-options.scss
+++ b/src/main/resources/public/sass/global/components/directives/_card-list-item-options.scss
@@ -1,5 +1,6 @@
   .cardDirective-list-item-options {
     transform: translateX(5px) translateY(-26px);
+    z-index: 2;
     nav {
       .nav, .sub-nav {
         position: absolute;


### PR DESCRIPTION
## Describe your changes
Add missing z-index to display card options properly.

## Checklist tests
Magneto module --> select a board --> open card options and you should see it properly (not under image preview/ vidéo or text)

## Issue ticket number and link
[MAG-226](https://jira.support-ent.fr/browse/MAG-226)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

