### PR TITLE
fix(boardDesc): #MAG-213 shrink space in board description

### DIFF
--- a/src/main/resources/public/sass/global/components/containers/_board.scss
+++ b/src/main/resources/public/sass/global/components/containers/_board.scss
@@ -71,7 +71,7 @@
     &-description {
       overflow: hidden !important;
       white-space: pre-line !important;
-      height: 28px !important;
+      height: 19px !important;
     }
 
     .create-button {


### PR DESCRIPTION
## Describe your changes
Shrink space in board description between description and "Lire plus" link to open popup when description is too long.

## Checklist tests
Go to Magneto --> Open a board with a long description --> resize the window to have mobile view.

## Issue ticket number and link
[MAG-213](https://jira.support-ent.fr/browse/MAG-213)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

