### PR TITLE
feat(boards): #MAG-228 add option to fetch boards from all folders

### DIFF
--- a/src/main/java/fr/cgi/magneto/controller/BoardController.java
+++ b/src/main/java/fr/cgi/magneto/controller/BoardController.java
@@ -63,9 +63,10 @@ public class BoardController extends ControllerHelper {
             boolean isPublic = Boolean.parseBoolean(request.getParam(Field.ISPUBLIC));
             boolean isShared = Boolean.parseBoolean(request.getParam(Field.ISSHARED));
             boolean isDeleted = Boolean.parseBoolean(request.getParam(Field.ISDELETED));
+            boolean allFolders = Boolean.parseBoolean(request.getParam(Field.ALLFOLDERS));
             String sortBy = request.getParam(Field.SORTBY);
             Integer page = request.getParam(Field.PAGE) != null ? Integer.parseInt(request.getParam(Field.PAGE)) : null;
-            boardService.getAllBoards(user, page, searchText, folderId, isPublic, isShared, isDeleted, sortBy)
+            boardService.getAllBoards(user, page, searchText, folderId, isPublic, isShared, isDeleted, sortBy, allFolders)
                     .onSuccess(result -> renderJson(request, result))
                     .onFailure(fail -> {
                         String message = String.format("[Magneto@%s::getAllBoards] Failed to get all boards : %s",

--- a/src/main/java/fr/cgi/magneto/core/constants/Field.java
+++ b/src/main/java/fr/cgi/magneto/core/constants/Field.java
@@ -68,6 +68,8 @@ public class Field {
     public static final String CANCOMMENT = "canComment";
     public static final String DISPLAY_NB_FAVORITES = "displayNbFavorites";
 
+    public static final String ALLFOLDERS = "allFolders";
+
     public static final String OWNER = "owner";
     public static final String USERID = "userId";
     public static final String GROUPID = "groupId";

--- a/src/main/java/fr/cgi/magneto/service/BoardService.java
+++ b/src/main/java/fr/cgi/magneto/service/BoardService.java
@@ -75,10 +75,11 @@ public interface BoardService {
      * @param isShared   fetch shared boards if true
      * @param isDeleted  fetch deleted boards if true
      * @param sortBy     Sort by parameter
+     * @param allFolders fetch all folders if true
      * @return Future {@link Future <JsonObject>} containing list of boards
      */
     Future<JsonObject> getAllBoards(UserInfos user, Integer page, String searchText, String folderId,
-                                    boolean isPublic, boolean isShared, boolean isDeleted, String sortBy);
+                                    boolean isPublic, boolean isShared, boolean isDeleted, String sortBy, boolean allFolders);
 
     /**
      * Get all boards with publish right

--- a/src/test/java/fr/cgi/magneto/service/BoardServiceTest.java
+++ b/src/test/java/fr/cgi/magneto/service/BoardServiceTest.java
@@ -154,7 +154,7 @@ public class BoardServiceTest {
         testUser.setUserId("ownerId");
 
         JsonObject query = Whitebox.invokeMethod(this.boardService, "getAllBoardsQuery", testUser, 0, "test", "folderId",
-                false, true, false, "name", true);
+                false, true, false, "name", true, false);
 
         ctx.assertEquals(expected, query);
     }


### PR DESCRIPTION
## Describe your changes

- added `allFolders` parameter for fetching user boards regardless of the folder they're in.

Updated API documentation : 

https://confluence.support-ent.fr/display/RN/Boards

## Checklist tests

- check if users is still fetching all boards as previously
- check if adding the `allFolders` parameter in the GET /boards API allows fetching all boards from user

## Issue ticket number and link

https://jira.support-ent.fr/browse/MAG-228

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

