### PR TITLE
fix(sections): #MAG-241 refresh card positions when scrolling in sections

### DIFF
--- a/src/main/resources/public/ts/directives/section-list/section-list-item.directive.ts
+++ b/src/main/resources/public/ts/directives/section-list/section-list-item.directive.ts
@@ -133,6 +133,7 @@ class Controller implements IViewModel {
                 if (res.all && res.all.length > 0) {
                     this.section.cards.push(...res.all);
                     this.infiniteScrollService.updateScroll();
+                    this.cardUpdateEventer.next();
                 }
                 this.isLoading = false;
                 safeApply(this.$scope);


### PR DESCRIPTION
## Describe your changes

- apply refresh of card positions when scrolling in a single section

## Checklist tests

- scroll on a section with more than 30 cards and verify if cards are not overlapping

## Issue ticket number and link

https://jira.support-ent.fr/browse/MAG-241

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

