### PR TITLE
fix(file-viewer): #MAG-111 display buttons only if the user has the proper rights

### DIFF
--- a/src/main/resources/public/template/board-read.html
+++ b/src/main/resources/public/template/board-read.html
@@ -29,7 +29,8 @@
 
         <!-- Card display -->
         <card-display
-                card="vm.card">
+                card="vm.card"
+                board="vm.board">
         </card-display>
 
         <!-- Comments panel -->

--- a/src/main/resources/public/template/board.html
+++ b/src/main/resources/public/template/board.html
@@ -219,7 +219,8 @@
                 card="vm.selectedCard"
                 display="vm.displayPreviewCardLightbox"
                 show-comments="vm.board.canComment"
-                board-owner="vm.board.owner">
+                board-owner="vm.board.owner"
+                board="vm.board">
         </card-preview-lightbox>
 
         <infinite-scroll ng-if="vm.board.isLayoutFree()"

--- a/src/main/resources/public/ts/directives/card-display/card-display.directive.ts
+++ b/src/main/resources/public/ts/directives/card-display/card-display.directive.ts
@@ -1,7 +1,7 @@
 import {ng, workspace} from "entcore";
 import {ILocationService, IParseService, IScope, IWindowService} from "angular";
 import {RootsConst} from "../../core/constants/roots.const";
-import {Card} from "../../models";
+import {Card, Board} from "../../models";
 import {DateUtils} from "../../utils/date.utils";
 import {RESOURCE_TYPE} from "../../core/enums/resource-type.enum";
 import {I18nUtils} from "../../utils/i18n.utils";
@@ -23,6 +23,7 @@ interface IViewModel extends ng.IController, ICardDisplayProps {
 
 interface ICardDisplayProps {
     card: Card;
+    board: Board;
 }
 
 interface ICardListItemScope extends IScope, ICardDisplayProps {
@@ -32,6 +33,7 @@ interface ICardListItemScope extends IScope, ICardDisplayProps {
 class Controller implements IViewModel {
 
     card: Card;
+    board: Board;
 
     RESOURCE_TYPES: typeof RESOURCE_TYPE;
 
@@ -82,6 +84,7 @@ function directive() {
         templateUrl: `${RootsConst.directive}card-display/card-display.html`,
         scope: {
             card: '=',
+            board: '='
         },
         controllerAs: 'vm',
         bindToController: true,

--- a/src/main/resources/public/ts/directives/card-display/card-display.html
+++ b/src/main/resources/public/ts/directives/card-display/card-display.html
@@ -10,7 +10,8 @@
     </div>
     <!--Card title-->
     <card-preview-image
-            card="vm.card">
+            card="vm.card"
+            board="vm.board">
     </card-preview-image>
     <div class="flex-row f-column">
         <!-- Card info -->

--- a/src/main/resources/public/ts/directives/card-list/card-preview-image.directive.ts
+++ b/src/main/resources/public/ts/directives/card-list/card-preview-image.directive.ts
@@ -1,7 +1,7 @@
 import {ng} from "entcore";
 import {ILocationService, IScope, IWindowService} from "angular";
 import {RootsConst} from "../../core/constants/roots.const";
-import {Card} from "../../models";
+import {Card, Board} from "../../models";
 import {RESOURCE_TYPE} from "../../core/enums/resource-type.enum";
 import {EXTENSION_FORMAT} from "../../core/constants/extension-format.const";
 
@@ -19,6 +19,7 @@ interface IViewModel extends ng.IController, ICardPreviewProps {
 
 interface ICardPreviewProps {
     card: Card;
+    board: Board;
 }
 
 interface ICardListItemScope extends IScope, ICardPreviewProps {
@@ -28,6 +29,7 @@ interface ICardListItemScope extends IScope, ICardPreviewProps {
 class Controller implements IViewModel {
 
     card: Card;
+    board: Board;
     RESOURCE_TYPES: typeof RESOURCE_TYPE;
 
 
@@ -101,6 +103,7 @@ function directive() {
         templateUrl: `${RootsConst.directive}card-list/card-preview-image.html`,
         scope: {
             card: '=',
+            board: '='
         },
         controllerAs: 'vm',
         bindToController: true,

--- a/src/main/resources/public/ts/directives/card-list/card-preview-image.html
+++ b/src/main/resources/public/ts/directives/card-list/card-preview-image.html
@@ -6,7 +6,8 @@
     <file-viewer ng-if="vm.card.isType(vm.RESOURCE_TYPES.FILE)"
                  file="vm.card.resource"
                  content-type="vm.card.resource.previewRole()"
-    ></file-viewer>
+                 has-download="vm.board.myRights.contrib !== undefined"
+                 has-edit="vm.board.myRights.publish !== undefined"></file-viewer>
     <a ng-href="[[vm.card.resourceUrl]]" target="_blank" ng-if="vm.card.isType(vm.RESOURCE_TYPES.LINK)">
         <img class="cardDirective-preview-image-icons" data-ng-src="/magneto/public/img/extension/link.svg">
     </a>

--- a/src/main/resources/public/ts/directives/card-manage-lightbox/card-manage-lightbox.html
+++ b/src/main/resources/public/ts/directives/card-manage-lightbox/card-manage-lightbox.html
@@ -51,7 +51,10 @@
             <!-- File preview -->
             <div class="cell cardDirective-manage-lightbox-content-body-resource-file"
                  ng-if="vm.form.resourceType == 'file' && vm.form._id">
-                    <file-viewer file="vm.form.resource" content-type="vm.form.resource.previewRole()"></file-viewer>
+                    <file-viewer file="vm.form.resource"
+                                 content-type="vm.form.resource.previewRole()"
+                                 has-download="vm.board.myRights.contrib !== undefined"
+                                 has-edit="vm.board.myRights.publish !== undefined"></file-viewer>
             </div>
             <div class="cell cardDirective-manage-lightbox-content-body-resource-file"
                  ng-if="vm.form.resourceType == 'file' && !vm.form._id">

--- a/src/main/resources/public/ts/directives/card-preview-lightbox/card-preview-lightbox.directive.ts
+++ b/src/main/resources/public/ts/directives/card-preview-lightbox/card-preview-lightbox.directive.ts
@@ -1,7 +1,7 @@
 import {ng} from "entcore";
 import {ILocationService, IScope, IWindowService} from "angular";
 import {RootsConst} from "../../core/constants/roots.const";
-import {Card, IBoardOwner} from "../../models";
+import {Card, Board, IBoardOwner} from "../../models";
 
 interface IViewModel extends ng.IController, ICardPreviewProps {
     closeForm(): void;
@@ -10,6 +10,8 @@ interface IViewModel extends ng.IController, ICardPreviewProps {
 interface ICardPreviewProps {
     display: boolean;
     card: Card;
+
+    board: Board;
     showComments: boolean;
     boardOwner: IBoardOwner;
 }
@@ -22,6 +24,8 @@ class Controller implements IViewModel {
 
     display: boolean;
     card: Card;
+
+    board: Board;
     showComments: boolean;
     boardOwner: IBoardOwner;
 
@@ -48,7 +52,8 @@ function directive() {
             display: '=',
             card: '=',
             showComments: '=',
-            boardOwner: '='
+            boardOwner: '=',
+            board: '='
         },
         controllerAs: 'vm',
         bindToController: true,

--- a/src/main/resources/public/ts/directives/card-preview-lightbox/card-preview-lightbox.html
+++ b/src/main/resources/public/ts/directives/card-preview-lightbox/card-preview-lightbox.html
@@ -2,7 +2,8 @@
           show="vm.display"
           on-close="vm.closeForm()">
     <card-display
-            card="vm.card">
+            card="vm.card"
+            board="vm.board">
     </card-display>
     <!-- Comments panel -->
     <comments-panel

--- a/src/main/resources/public/ts/directives/file-viewer/file-viewer.directive.ts
+++ b/src/main/resources/public/ts/directives/file-viewer/file-viewer.directive.ts
@@ -7,6 +7,7 @@ import * as util from "util";
 import {safeApply} from "../../utils/safe-apply.utils";
 import {FileViewModel} from "./FileViewerModel";
 import {hasRight} from "../../utils/rights.utils";
+import {Board} from "../../models";
 
 
 const workspaceService = workspace.v2.service;
@@ -40,6 +41,9 @@ interface IViewModel extends ng.IController , IFileViewerProps{
 interface IFileViewerProps {
     file: FileViewModel;
     contentType: string;
+
+    hasDownload: boolean;
+    hasEdit: boolean;
 }
 
 interface IFileViewerScope extends IScope, IFileViewerProps {
@@ -48,6 +52,9 @@ interface IFileViewerScope extends IScope, IFileViewerProps {
 
 class Controller implements IViewModel {
     contentType: string;
+
+    hasDownload: boolean;
+    hasEdit: boolean;
     file: FileViewModel;
     hasRight: typeof hasRight = hasRight;
     constructor(private $scope: IFileViewerScope,
@@ -68,7 +75,7 @@ class Controller implements IViewModel {
         workspaceService.downloadFiles([this.file]);
     };
     canDownload = () => {
-        return workspaceService.isActionAvailable("download", [this.file])
+        return this.hasDownload && workspaceService.isActionAvailable("download", [this.file])
     }
 
     edit = (): void => {
@@ -77,7 +84,7 @@ class Controller implements IViewModel {
     canEdit = (): boolean => {
         const ext: string[] = ['doc', 'ppt', "xls"];
         const isoffice: boolean = ext.includes(this.contentType);
-        return isoffice && Behaviours.applicationsBehaviours['lool'].canBeOpenOnLool(this.file);
+        return this.hasEdit && isoffice && Behaviours.applicationsBehaviours['lool'].canBeOpenOnLool(this.file);
     }
 
     isOfficePdf = () => {
@@ -162,7 +169,9 @@ function directive(){
         restrict: 'E',
         scope: {
             file: '=',
-            contentType: '='
+            contentType: '=',
+            hasDownload: '=',
+            hasEdit: '='
         },
         templateUrl: `${RootsConst.directive}/file-viewer/file-viewer.html`,
         controllerAs: 'vm',


### PR DESCRIPTION
## Describe your changes

- display "Download" and "Edit" buttons in file viewer only if the user has the rights (through sharing)

## Checklist tests

- share a board to a user
- if the user has "read" right, no button should be displayed
- if the user has the "reuse" right, the download button should be displayed"
- if the user has a "write" right, the "edit" button should be displayed

## Issue ticket number and link

https://jira.support-ent.fr/browse/MAG-111

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

