### PR TITLE
feat(preview): #MAG-111 replace preview if incompatible file type

### DIFF
--- a/src/main/resources/public/sass/global/components/directives/_card-preview-image.scss
+++ b/src/main/resources/public/sass/global/components/directives/_card-preview-image.scss
@@ -1,4 +1,15 @@
 .cardDirective-preview-image {
+
+  &-archive {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    span {
+      padding: 15px;
+    }
+  }
+
   &-icons {
     height: 30vh;
     width: 100%;

--- a/src/main/resources/public/ts/directives/card-list/card-preview-image.html
+++ b/src/main/resources/public/ts/directives/card-list/card-preview-image.html
@@ -3,7 +3,14 @@
     <img ng-if="vm.card.isType(vm.RESOURCE_TYPES.IMAGE)"
          ng-src="/workspace/document/[[vm.card.resourceId]]"
          ng-class="cardDirective-preview-image-img">
-    <file-viewer ng-if="vm.card.isType(vm.RESOURCE_TYPES.FILE)"
+    <div ng-if="vm.card.isType(vm.RESOURCE_TYPES.FILE) && vm.card.isCompressed()" class="cardDirective-preview-image-archive">
+        <img class="card-preview-image-icons"
+             ng-click="vm.downloadFile()"
+             data-ng-src="/magneto/public/img/extension/[[vm.getExtension()]].svg">
+        <span>[[vm.card.metadata.filename]]</span>
+    </div>
+
+    <file-viewer ng-if="vm.card.isType(vm.RESOURCE_TYPES.FILE) && !vm.card.isCompressed()"
                  file="vm.card.resource"
                  content-type="vm.card.resource.previewRole()"
                  has-download="vm.board.myRights.contrib !== undefined"

--- a/src/main/resources/public/ts/directives/file-viewer/file-viewer.html
+++ b/src/main/resources/public/ts/directives/file-viewer/file-viewer.html
@@ -2,7 +2,7 @@
     <div class="controls__navbar flex-row align-center justify-between" ng-if="!isFullscreen">
         <div class="flex-row file-viewer-navbar-header align-center justify-between">
             <div class="flex-row f-column ">
-                <h2 class="file-viewer-file-name-ellipsis no-margin" tooltip="[[vm.file.name]]">[[vm.file.name]]</h2>
+                <h2 class="file-viewer-file-name-ellipsis no-margin" tooltip="[[vm.file.name]]">[[vm.file.metadata.filename]]</h2>
                 <small><span class="no-1d"><i18n>owner</i18n>:&nbsp;</span><strong>[[vm.file.ownerName]]</strong></small>
             </div>
         </div>

--- a/src/main/resources/public/ts/models/card.model.ts
+++ b/src/main/resources/public/ts/models/card.model.ts
@@ -458,6 +458,13 @@ export class Card {
     isType = (resourceType: string): boolean => {
         return this.resourceType == resourceType;
     }
+
+    isCompressed = (): boolean => {
+        return this.metadata && this.metadata["content-type"] && (
+            this.metadata["content-type"].includes("zip") ||
+            this.metadata["content-type"].includes("octet-stream"));
+    }
+
     get resource(): FileViewModel {
         return this._resource;
     }


### PR DESCRIPTION
## Describe your changes

- replaced file preview with default file icon with filename when file type is not supported
- display full filename in file-preview

![image](https://github.com/OPEN-ENT-NG/magneto/assets/45894263/a43983a1-8c96-4303-b521-cf6dd4e6bd86)


## Checklist tests

- add a zip file or another file type (not image, pdf or Only Office supported file)
- check if the preview is replaced by default image

## Issue ticket number and link

https://jira.support-ent.fr/browse/MAG-111

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

