### PR TITLE
fix(board) : #MAG-111 fix documents which couldnt be opened with LibreOfficeOnline.

### DIFF
--- a/src/main/java/fr/cgi/magneto/core/constants/Field.java
+++ b/src/main/java/fr/cgi/magneto/core/constants/Field.java
@@ -215,6 +215,7 @@ public class Field {
     public static final String GROUPS = "groups";
     public static final String BOOKMARKS = "bookmarks";
     public static final String BOOKMARKID = "bookmarkId";
+    public static final String EXTENSION = "extension";
     public static final String TYPE = "type";
     public static final String MY_BOARDS = "my-boards";
     public static final String GROUP_TYPE = "groupType";

--- a/src/main/java/fr/cgi/magneto/model/Metadata.java
+++ b/src/main/java/fr/cgi/magneto/model/Metadata.java
@@ -10,6 +10,7 @@ public class Metadata implements Model {
     private final String contentTransferEncoding;
     private final String charset;
     private final Integer size;
+    private final String extension;
 
     public Metadata(JsonObject metadata) {
         this.name = metadata.getString(Field.NAME, null);
@@ -18,6 +19,7 @@ public class Metadata implements Model {
         this.contentTransferEncoding = metadata.getString(Field.CONTENT_TRANSFER_ENCODING, null);
         this.charset = metadata.getString(Field.CHARSET, null);
         this.size = metadata.getInteger(Field.SIZE, null);
+        this.extension = filename.substring(filename.lastIndexOf('.') + 1);
     }
 
     public String getName() {
@@ -40,9 +42,12 @@ public class Metadata implements Model {
         return charset;
     }
 
-
     public Integer getSize() {
         return size;
+    }
+
+    public String getExtension() {
+        return extension;
     }
 
 
@@ -54,7 +59,8 @@ public class Metadata implements Model {
                 .put(Field.CONTENT_TYPE, this.getContentType())
                 .put(Field.CONTENT_TRANSFER_ENCODING, this.getContentTransferEncoding())
                 .put(Field.CHARSET, this.getCharset())
-                .put(Field.SIZE, this.getSize());
+                .put(Field.SIZE, this.getSize())
+                .put(Field.EXTENSION, this.getExtension());
     }
 
     @Override

--- a/src/test/java/fr/cgi/magneto/model/MetadataTest.java
+++ b/src/test/java/fr/cgi/magneto/model/MetadataTest.java
@@ -11,11 +11,12 @@ public class MetadataTest {
 
     JsonObject metadataJsonObject = new JsonObject()
             .put("name", "name")
-            .put("filename", "filename")
+            .put("filename", "filename.test")
             .put("content-type", "contentType")
             .put("content-transfer-encoding", "contentTransferEncoding")
             .put("charset", "charset")
-            .put("size", 1);
+            .put("size", 1)
+            .put("extension", "test");
 
 
     @Test


### PR DESCRIPTION
## Describe your changes
fix documents which couldnt be opened with LibreOfficeOnline because of a missing extension.

## Checklist tests
Try to open a document with LibreOfficeOnline as lool provider.

## Issue ticket number and link
[MAG-111](https://jira.support-ent.fr/browse/MAG-111)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

