### PR TITLE
fix(notifications): #MAG-286  fix notifications

### DIFF
--- a/src/main/java/fr/cgi/magneto/controller/ShareBoardController.java
+++ b/src/main/java/fr/cgi/magneto/controller/ShareBoardController.java
@@ -166,8 +166,8 @@ public class ShareBoardController extends ControllerHelper {
         Promise<List<String>> promise = Promise.promise();
         List<Future<List<String>>> futures = new ArrayList<>();
         newSharedElem.forEach(elem -> {
-            if (elem.getTypeId().equals(Field.USERID) && !elem.getId().equals(user.getUserId())){
-                    usersIdToShare.add(elem.getId());
+            if (elem.getTypeId().equals(Field.USERID) && !elem.getId().equals(user.getUserId())) {
+                usersIdToShare.add(elem.getId());
             }
             if (elem.getTypeId().equals(Field.GROUPID)) {
                 futures.add(getGroupUsers(user, elem.getId()));

--- a/src/main/java/fr/cgi/magneto/controller/ShareBoardController.java
+++ b/src/main/java/fr/cgi/magneto/controller/ShareBoardController.java
@@ -25,6 +25,7 @@ import org.entcore.common.user.UserInfos;
 import org.entcore.common.user.UserUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -261,9 +262,7 @@ public class ShareBoardController extends ControllerHelper {
     private void handleShareFolder(HttpServerRequest request, UserInfos user, List<SharedElem> newSharedElem, String id, I18nHelper i18nHelper, JsonObject share) {
 
         Future<List<SharedElem>> deletedRightFuture = this.magnetoShareService.getDeletedRights(id, newSharedElem, CollectionsConstant.FOLDER_COLLECTION);
-        List<String> idArray = new ArrayList<>();
-        idArray.add(id);
-        Future<JsonArray> getFolderDataFuture = this.folderService.getFolders(idArray);
+        Future<JsonArray> getFolderDataFuture = this.folderService.getFolders(Collections.singletonList(id));;
         SharedElem ownerRights = ShareHelper.getOwnerSharedElem(user.getUserId());
         if (!newSharedElem.isEmpty())
             newSharedElem.add(ownerRights);

--- a/src/main/java/fr/cgi/magneto/controller/ShareBoardController.java
+++ b/src/main/java/fr/cgi/magneto/controller/ShareBoardController.java
@@ -166,8 +166,8 @@ public class ShareBoardController extends ControllerHelper {
         Promise<List<String>> promise = Promise.promise();
         List<Future<List<String>>> futures = new ArrayList<>();
         newSharedElem.forEach(elem -> {
-            if (elem.getTypeId().equals(Field.USERID)) {
-                usersIdToShare.add(elem.getId());
+            if (elem.getTypeId().equals(Field.USERID) && !elem.getId().equals(user.getUserId())){
+                    usersIdToShare.add(elem.getId());
             }
             if (elem.getTypeId().equals(Field.GROUPID)) {
                 futures.add(getGroupUsers(user, elem.getId()));
@@ -261,6 +261,9 @@ public class ShareBoardController extends ControllerHelper {
     private void handleShareFolder(HttpServerRequest request, UserInfos user, List<SharedElem> newSharedElem, String id, I18nHelper i18nHelper, JsonObject share) {
 
         Future<List<SharedElem>> deletedRightFuture = this.magnetoShareService.getDeletedRights(id, newSharedElem, CollectionsConstant.FOLDER_COLLECTION);
+        List<String> idArray = new ArrayList<>();
+        idArray.add(id);
+        Future<JsonArray> getFolderDataFuture = this.folderService.getFolders(idArray);
         SharedElem ownerRights = ShareHelper.getOwnerSharedElem(user.getUserId());
         if (!newSharedElem.isEmpty())
             newSharedElem.add(ownerRights);
@@ -279,6 +282,7 @@ public class ShareBoardController extends ControllerHelper {
                             if (Boolean.TRUE.equals(checkRight)) {
                                 deletedRightFuture
                                         .compose(deleteRights -> this.folderService.shareFolder(id, newSharedElem, deleteRights))
+                                        .compose(r -> getFolderDataFuture)
                                         .compose(success -> this.folderService.getChildrenBoardsIds(id))
                                         .compose(boardsIds -> this.boardService.shareBoard(boardsIds, newSharedElem, deletedRightFuture.result(), true))
                                         .compose(boardsIds -> this.workspaceService.setShareRights(boardsIds, share))
@@ -287,16 +291,17 @@ public class ShareBoardController extends ControllerHelper {
                                             JsonObject params = new JsonObject();
                                             params.put(Field.PROFILURI, "/userbook/annuaire#" + user.getUserId() + "#" + user.getType());
                                             params.put(Field.USERNAME, user.getUsername());
-                                            params.put(Field.BOARDURL, "/magneto#/");
+                                            params.put(Field.FOLDERURL, "/magneto#/");
+                                            if (!getFolderDataFuture.result().isEmpty())
+                                                params.put(Field.FOLDERTITLE, getFolderDataFuture.result().getJsonObject(0).getValue(Field.TITLE, ""));
 
                                             JsonObject pushNotif = new JsonObject()
                                                     .put(Field.TITLE, "push.notif.magneto.share")
                                                     .put(Field.BODY, user.getUsername() + " " + i18nHelper.translate("magneto.shared.push.notif.body"));
                                             params.put(Field.PUSHNOTIF, pushNotif);
-
                                             getUsersIdsToNotify(user, newSharedElem)
                                                     .onSuccess(usersIdToShare -> {
-                                                        notification.notifyTimeline(request, "magneto.share_board", user, usersIdToShare, id, Field.TITLE,
+                                                        notification.notifyTimeline(request, "magneto.share_folder", user, usersIdToShare, id, Field.TITLE,
                                                                 params, true);
                                                         request.response().setStatusMessage(id).setStatusCode(200).end();
                                                     }).onFailure(error -> badRequest(request, error.getMessage()));

--- a/src/main/java/fr/cgi/magneto/core/constants/Field.java
+++ b/src/main/java/fr/cgi/magneto/core/constants/Field.java
@@ -226,4 +226,7 @@ public class Field {
     public static final String GROUP_TYPE = "groupType";
     public static final String GROUP = "Group";
     public static final String MEMBERS = "members";
+    //notification Folder
+    public static final String FOLDERTITLE = "folderTitle";
+    public static final String FOLDERURL = "folderUrl";
 }

--- a/src/main/resources/i18n/timeline/de.json
+++ b/src/main/resources/i18n/timeline/de.json
@@ -1,7 +1,9 @@
 {
   "push.notif.magneto.share": "Magneto: Share board",
+  "push.notif.magneto.share.folder": "Magneto: Share folder",
   "timeline.magneto.shared": "has given you access to a new board",
   "timeline.magneto.shared.link.board": "board link",
+  "timeline.magneto.shared.link.folder": "folder link",
   "magneto.share_board": "Sharing a board",
   "magneto.share_folder": "Sharing a folder"
 }

--- a/src/main/resources/i18n/timeline/en.json
+++ b/src/main/resources/i18n/timeline/en.json
@@ -1,7 +1,9 @@
 {
   "push.notif.magneto.share": "Magneto: Share board",
+  "push.notif.magneto.share.folder": "Magneto: Share folder",
   "timeline.magneto.shared": "has given you access to a new board",
   "timeline.magneto.shared.link.board": "board link",
+  "timeline.magneto.shared.link.folder": "folder link",
   "magneto.share_board": "Sharing a board",
   "magneto.share_folder": "Sharing a folder"
 }

--- a/src/main/resources/i18n/timeline/es.json
+++ b/src/main/resources/i18n/timeline/es.json
@@ -1,7 +1,9 @@
 {
   "push.notif.magneto.share": "Magneto: Share board",
+  "push.notif.magneto.share.folder": "Magneto: Share folder",
   "timeline.magneto.shared": "has given you access to a new board",
   "timeline.magneto.shared.link.board": "board link",
+  "timeline.magneto.shared.link.folder": "folder link",
   "magneto.share_board": "Sharing a board",
   "magneto.share_folder": "Sharing a folder"
 }

--- a/src/main/resources/i18n/timeline/fr.json
+++ b/src/main/resources/i18n/timeline/fr.json
@@ -1,9 +1,10 @@
 {
   "push.notif.magneto.share": "Magneto: Partage d'un tableau",
+  "push.notif.magneto.share.folder": "Magneto: Partage d'un dossier",
   "timeline.magneto.shared": "vous a donné accès à un nouveau tableau",
   "timeline.magneto.shared.folder": "vous a donné accès à un nouveau dossier",
   "timeline.magneto.shared.link.board": "lien du tableau",
-  "timeline.magneto.shared.link.folder": "lien du dossier",
+  "timeline.magneto.shared.link.folder": "lien vers Magnéto",
   "magneto.share_board": "Partage d'un tableau",
   "magneto.share_folder": "Partage d'un dossier"
 }

--- a/src/main/resources/i18n/timeline/it.json
+++ b/src/main/resources/i18n/timeline/it.json
@@ -1,6 +1,8 @@
 {
   "push.notif.magneto.share": "Magneto: Share board",
+  "push.notif.magneto.share.folder": "Magneto: Share folder",
   "timeline.magneto.shared": "has given you access to a new board",
+  "timeline.magneto.shared.link.folder": "folder link",
   "magneto.share_board": "Sharing a board",
   "magneto.share_folder": "Sharing a folder"
 }

--- a/src/main/resources/i18n/timeline/pt.json
+++ b/src/main/resources/i18n/timeline/pt.json
@@ -1,7 +1,9 @@
 {
   "push.notif.magneto.share": "Magneto: Share board",
+  "push.notif.magneto.share.folder": "Magneto: Share folder",
   "timeline.magneto.shared": "has given you access to a new board",
   "timeline.magneto.shared.link.board": "board link",
+  "timeline.magneto.shared.link.folder": "folder link",
   "magneto.share_board": "Sharing a board",
   "magneto.share_folder": "Sharing a folder"
 }

--- a/src/main/resources/view-src/notify/share_folder.html
+++ b/src/main/resources/view-src/notify/share_folder.html
@@ -1,9 +1,10 @@
-<a>{{#i18n}}push.notif.magneto.share{{/i18n}}</a>
+<a>{{#i18n}}push.notif.magneto.share.folder{{/i18n}}</a>
 <br />
 <span>
     <span>
         <a href="{{#host}}{{profilUri}}{{/host}}">{{username}}</a>
-        {{#i18n}}timeline.magneto.shared.folder{{/i18n}}&nbsp;:
-        <a href="{{boardUrl}}">{{#i18n}}timeline.magneto.shared.link.board{{/i18n}}</a>
+        {{#i18n}}timeline.magneto.shared.folder{{/i18n}}&nbsp;&quot;&nbsp;{{folderTitle}}&nbsp;&quot;&nbsp;&#58;
+        <br/>
+        <a href="{{folderUrl}}">{{#i18n}}timeline.magneto.shared.link.folder{{/i18n}}</a>
     </span>
 </span>


### PR DESCRIPTION
## Describe your changes
fix notifications for share folders : 
- no longer notify the owner of the folder
- no longer notify with the boards notifications 
- improve folder notification (add title)

## Checklist tests
- Sharing a folder doesn't throw a notification to the owner
- Sharing a folder throw the correct folder notification with title 

## Issue ticket number and link
https://jira.support-ent.fr/browse/MAG-286
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

