### PR TITLE
fix(Boards): #MAG-383 fix get boards now handle board with one folder

### DIFF
--- a/src/main/java/fr/cgi/magneto/core/constants/Mongo.java
+++ b/src/main/java/fr/cgi/magneto/core/constants/Mongo.java
@@ -68,4 +68,5 @@ public class Mongo {
     public static final String PIPELINE = "$pipeline";
 
     public static final String RESTRICT_SEARCH_WITH_MATCH = "restrictSearchWithMatch";
+    public static final String IFNULL =  "$ifNull";
 }

--- a/src/main/java/fr/cgi/magneto/core/constants/Mongo.java
+++ b/src/main/java/fr/cgi/magneto/core/constants/Mongo.java
@@ -69,4 +69,5 @@ public class Mongo {
 
     public static final String RESTRICT_SEARCH_WITH_MATCH = "restrictSearchWithMatch";
     public static final String IFNULL =  "$ifNull";
+    public static final String GT = "$gt";
 }


### PR DESCRIPTION
## Describe your changes
fix folders filter when getting boards : now doesn't return folderId if the user cant access the folder

## Checklist tests
Each boards return must be in their folder if the user has acces to said folder or be present in the main page without folderId

## Issue ticket number and link

https://jira.support-ent.fr/browse/MAG-383

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

