### PR TITLE
#MAG-353 resolve duplicate upload issue in multiple instances

### DIFF
--- a/frontend/src/components/create-board/CreateBoard.tsx
+++ b/frontend/src/components/create-board/CreateBoard.tsx
@@ -1,26 +1,24 @@
 import React, { FunctionComponent, useEffect, useState } from "react";
 
-// eslint-disable-next-line
+// eslint-disable-next-line import/order
 import {
   Button,
   Checkbox,
   FormControl,
   Grid,
-  ImagePicker,
   Input,
   Label,
   Modal,
   Radio,
   TextArea,
 } from "@edifice-ui/react";
-
 import "./CreateBoard.scss";
-
 import ViewColumnOutlinedIcon from "@mui/icons-material/ViewColumnOutlined";
 import ViewQuiltOutlinedIcon from "@mui/icons-material/ViewQuiltOutlined";
 import ViewStreamOutlinedIcon from "@mui/icons-material/ViewStreamOutlined";
 import { useTranslation } from "react-i18next";
 
+import UniqueImagePicker from "../unique-image-picker/UniqueImagePicker";
 import { LAYOUT_TYPE } from "~/core/enums/layout-type.enum";
 import useImageHandler from "~/hooks/useImageHandler";
 import useWindowDimensions from "~/hooks/useWindowDimensions";
@@ -175,6 +173,8 @@ export const CreateBoard: FunctionComponent<props> = ({
 
   useEffect(() => {
     if (boardToUpdate != null) {
+      console.log("slip");
+
       setIsCommentChecked(boardToUpdate.canComment);
       setIsFavoriteChecked(boardToUpdate.displayNbFavorites);
       setTitle(boardToUpdate.title);
@@ -214,16 +214,21 @@ export const CreateBoard: FunctionComponent<props> = ({
                   padding: ".8rem",
                 }}
               >
-                <ImagePicker
+                <UniqueImagePicker
                   addButtonLabel="Add image"
                   deleteButtonLabel="Delete image"
                   label="Upload an image"
-                  onDeleteImage={() => {
-                    handleDeleteImageThumbnail();
-                    setThumbnailSrc("");
-                  }}
                   onUploadImage={handleUploadImageThumbnail}
+                  onDeleteImage={handleDeleteImageThumbnail}
                   src={thumbnailSrc}
+                  onImageChange={(file) => {
+                    if (file) {
+                      handleUploadImageThumbnail(file);
+                    } else {
+                      handleDeleteImageThumbnail();
+                      setThumbnailSrc("");
+                    }
+                  }}
                 />
                 {(thumbnail == "" || thumbnail == null) &&
                   thumbnailSrc == "" && (
@@ -349,16 +354,21 @@ export const CreateBoard: FunctionComponent<props> = ({
                     <div className="mb-0-5">
                       {t("magneto.board.background.title")}
                     </div>
-                    <ImagePicker
+                    <UniqueImagePicker
                       addButtonLabel="Add image"
                       deleteButtonLabel="Delete image"
                       label="Upload an image"
-                      onDeleteImage={() => {
-                        handleDeleteImageBackground();
-                        setBackgroundSrc("");
-                      }}
                       onUploadImage={handleUploadImageBackground}
+                      onDeleteImage={handleDeleteImageBackground}
                       src={backgroundSrc}
+                      onImageChange={(file) => {
+                        if (file) {
+                          handleUploadImageBackground(file);
+                        } else {
+                          handleDeleteImageBackground();
+                          setBackgroundSrc("");
+                        }
+                      }}
                     />
                     <i className="font-little">
                       {t("magneto.board.background.warning")}

--- a/frontend/src/components/create-board/CreateBoard.tsx
+++ b/frontend/src/components/create-board/CreateBoard.tsx
@@ -173,8 +173,6 @@ export const CreateBoard: FunctionComponent<props> = ({
 
   useEffect(() => {
     if (boardToUpdate != null) {
-      console.log("slip");
-
       setIsCommentChecked(boardToUpdate.canComment);
       setIsFavoriteChecked(boardToUpdate.displayNbFavorites);
       setTitle(boardToUpdate.title);

--- a/frontend/src/components/create-board/CreateBoard.tsx
+++ b/frontend/src/components/create-board/CreateBoard.tsx
@@ -243,7 +243,7 @@ export const CreateBoard: FunctionComponent<props> = ({
                 <div>
                   <div>
                     <FormControl id="title" className="mb-0-5">
-                      <Label>{t("magneto.create.board.title")} *:</Label>
+                      <Label>{t("magneto.create.board.title")} * :</Label>
                       <Input
                         value={title}
                         placeholder=""
@@ -253,7 +253,7 @@ export const CreateBoard: FunctionComponent<props> = ({
                       />
                     </FormControl>
                     <FormControl id="description" className="mb-1-5">
-                      <Label>{t("magneto.create.board.description")}</Label>
+                      <Label>{t("magneto.create.board.description")} :</Label>
                       <TextArea
                         size="md"
                         value={description}
@@ -332,7 +332,7 @@ export const CreateBoard: FunctionComponent<props> = ({
                   </div>
                   <div className="mb-1">
                     <FormControl id="keywords">
-                      <Label>{t("magneto.board.keywords")}</Label>
+                      <Label>{t("magneto.board.keywords")} :</Label>
                       <Input
                         placeholder=""
                         size="md"
@@ -371,9 +371,9 @@ export const CreateBoard: FunctionComponent<props> = ({
           <Modal.Footer>
             <div className="right">
               <Button
-                color="primary"
+                color="tertiary"
                 type="button"
-                variant="outline"
+                variant="ghost"
                 className="footer-button"
                 onClick={resetFields}
               >
@@ -389,7 +389,7 @@ export const CreateBoard: FunctionComponent<props> = ({
                   (thumbnailSrc == "" && thumbnail == "") || title == ""
                 }
               >
-                {t("magneto.save")}
+                {boardToUpdate ? t("magneto.save") : t("magneto.create")}
               </Button>
             </div>
           </Modal.Footer>

--- a/frontend/src/components/unique-image-picker/UniqueImagePicker.tsx
+++ b/frontend/src/components/unique-image-picker/UniqueImagePicker.tsx
@@ -1,0 +1,88 @@
+import React, { useRef, useCallback, useEffect } from "react";
+
+import { ImagePicker, ImagePickerProps } from "@edifice-ui/react";
+
+interface UniqueImagePickerProps extends ImagePickerProps {
+  onImageChange: (file: File | null) => void;
+}
+
+const UniqueImagePicker: React.FC<UniqueImagePickerProps> = ({
+  onImageChange,
+  ...props
+}) => {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const idRef = useRef(
+    `image-picker-${Math.random().toString(36).substring(2, 11)}`,
+  );
+  const isClickingButton = useRef(false);
+
+  const handleUploadImage = useCallback(
+    (file: File) => {
+      onImageChange(file);
+    },
+    [onImageChange],
+  );
+
+  const handleDeleteImage = useCallback(() => {
+    onImageChange(null);
+  }, [onImageChange]);
+
+  useEffect(() => {
+    const wrapperElement = wrapperRef.current;
+
+    const handleClick = (event: MouseEvent) => {
+      if (wrapperElement && wrapperElement.contains(event.target as Node)) {
+        const target = event.target as HTMLElement;
+        if (target.tagName !== "INPUT" && !isClickingButton.current) {
+          event.preventDefault();
+          event.stopPropagation();
+          inputRef.current?.click();
+        }
+      }
+    };
+
+    const handleButtonMouseDown = () => {
+      isClickingButton.current = true;
+    };
+
+    const handleButtonMouseUp = () => {
+      setTimeout(() => {
+        isClickingButton.current = false;
+      }, 0);
+    };
+
+    document.addEventListener("click", handleClick);
+
+    const buttons = wrapperElement?.querySelectorAll("button");
+    buttons?.forEach((button) => {
+      button.addEventListener("mousedown", handleButtonMouseDown);
+      button.addEventListener("mouseup", handleButtonMouseUp);
+    });
+
+    return () => {
+      document.removeEventListener("click", handleClick);
+      buttons?.forEach((button) => {
+        button.removeEventListener("mousedown", handleButtonMouseDown);
+        button.removeEventListener("mouseup", handleButtonMouseUp);
+      });
+    };
+  }, []);
+
+  return (
+    <div ref={wrapperRef} id={idRef.current}>
+      <ImagePicker
+        {...props}
+        onUploadImage={handleUploadImage}
+        onDeleteImage={handleDeleteImage}
+        ref={(el) => {
+          if (el) {
+            inputRef.current = el.querySelector('input[type="file"]');
+          }
+        }}
+      />
+    </div>
+  );
+};
+
+export default UniqueImagePicker;


### PR DESCRIPTION
## CreateBoard style fixed & ImagePicker upload issue fixed

## Checklist tests

## [MAG-353](https://jira.support-ent.fr/browse/MAG-353)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

create-board style fixed

To resolve the initial issue where clicking on the drop zone of the second ImagePicker component placed the image in the first one, I encapsulated the component in a **wrapper (UniqueImagePicker) and used refs (wrapperRef, inputRef, idRef) to manage each instance uniquely**. 
I added event handlers to the document to check if the click occurred inside our specific component, avoiding redundant clicks.