### PR TITLE
fix(Board) : #MAG-353 boards are created in the right folder

### DIFF
--- a/frontend/src/components/create-board/CreateBoard.tsx
+++ b/frontend/src/components/create-board/CreateBoard.tsx
@@ -23,6 +23,7 @@ import { LAYOUT_TYPE } from "~/core/enums/layout-type.enum";
 import useImageHandler from "~/hooks/useImageHandler";
 import useWindowDimensions from "~/hooks/useWindowDimensions";
 import { Board, BoardForm } from "~/models/board.model";
+import { useFoldersNavigation } from "~/providers/FoldersNavigationProvider";
 import {
   useCreateBoardMutation,
   useUpdateBoardMutation,
@@ -61,6 +62,7 @@ export const CreateBoard: FunctionComponent<props> = ({
     handleDeleteImage: handleDeleteImageBackground,
     fetchUrl: fetchBackgroundUrl,
   } = useImageHandler("");
+  const { currentFolder } = useFoldersNavigation();
   const [isCommentChecked, setIsCommentChecked] = useState(false);
   const [isFavoriteChecked, setIsFavoriteChecked] = useState(false);
   const [title, setTitle] = useState("");
@@ -78,6 +80,7 @@ export const CreateBoard: FunctionComponent<props> = ({
   const setBoardFromForm = async (board: BoardForm) => {
     board.title = title;
     board.description = description;
+    board.folderId = currentFolder.id;
 
     if (thumbnailSrc != "" && thumbnail == "") {
       board.imageUrl = thumbnailSrc;


### PR DESCRIPTION
## add currentFolder.id to boardForm in CreateBoard

## Checklist tests

## [MAG-353](https://jira.support-ent.fr/browse/MAG-353)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

boards are now created in currentFolder
![image](https://github.com/user-attachments/assets/4f989358-594b-48ff-9b22-7adeb3b8a65c)
