### PR TITLE
fix(treeview) : #MAG-390 fix highlighting of folder with subfolder

### DIFF
--- a/frontend/src/components/folder-item/FolderItem.tsx
+++ b/frontend/src/components/folder-item/FolderItem.tsx
@@ -6,13 +6,13 @@ import { mdiFolder, mdiFolderAccount } from "@mdi/js";
 import Icon from "@mdi/react";
 import { useDrop } from "react-dnd";
 
+import { DRAG_AND_DROP_TYPE } from "~/core/enums/drag-and-drop-type.enum";
 import { FOLDER_TYPE, MAIN_PAGE_TITLE } from "~/core/enums/folder-type.enum";
 import { Board } from "~/models/board.model";
 import { Folder } from "~/models/folder.model";
 import { useFoldersNavigation } from "~/providers/FoldersNavigationProvider";
 import { useMoveBoardsMutation } from "~/services/api/boards.service";
 import { UserRights } from "~/utils/share.utils";
-import { DRAG_AND_DROP_TYPE } from "~/core/enums/drag-and-drop-type.enum";
 
 type FolderListProps = {
   isSelected: boolean;

--- a/frontend/src/components/folder-item/FolderItem.tsx
+++ b/frontend/src/components/folder-item/FolderItem.tsx
@@ -12,6 +12,7 @@ import { Folder } from "~/models/folder.model";
 import { useFoldersNavigation } from "~/providers/FoldersNavigationProvider";
 import { useMoveBoardsMutation } from "~/services/api/boards.service";
 import { UserRights } from "~/utils/share.utils";
+import { DRAG_AND_DROP_TYPE } from "~/core/enums/drag-and-drop-type.enum";
 
 type FolderListProps = {
   isSelected: boolean;
@@ -223,7 +224,11 @@ export const FolderItem: React.FunctionComponent<FolderListProps> = ({
       <div
         ref={drop}
         draggable="true"
-        className={isOver ? "drag-over" : "no-drag-over"}
+        className={
+          isOver
+            ? DRAG_AND_DROP_TYPE.DRAG_OVER
+            : DRAG_AND_DROP_TYPE.NO_DRAG_OVER
+        }
       >
         <Card
           app={currentApp!}

--- a/frontend/src/components/tree-view/TreeViewContainer.tsx
+++ b/frontend/src/components/tree-view/TreeViewContainer.tsx
@@ -67,36 +67,16 @@ export const TreeViewContainer: React.FunctionComponent<
   };
 
   const removeFolderHighlight = (e: React.ChangeEvent<HTMLInputElement>) => {
-    let targetElement: HTMLElement;
-    if (e.target.closest("li")?.id) {
-      if (
-        e.target.closest("li")?.id.split("_")[1] == FOLDER_TYPE.MY_BOARDS ||
-        e.target.closest("li")?.id.split("_")[1] == FOLDER_TYPE.PUBLIC_BOARDS ||
-        e.target.closest("li")?.id.split("_")[1] == FOLDER_TYPE.DELETED_BOARDS
-      ) {
-        targetElement =
-          e.target.closest(".action-container") ?? new HTMLElement();
-      } else {
-        targetElement = e.target.closest("li") ?? new HTMLElement();
-      }
+    const targetElement = e.target.closest(".action-container");
+    if (targetElement) {
       targetElement.classList.add("no-drag-over");
       targetElement.classList.remove("drag-over");
     }
   };
 
   const handleDragOver = (e: React.ChangeEvent<HTMLInputElement>) => {
-    let targetElement: HTMLElement;
-    if (e.target.closest("li")?.id) {
-      if (
-        e.target.closest("li")?.id.split("_")[1] == FOLDER_TYPE.MY_BOARDS ||
-        e.target.closest("li")?.id.split("_")[1] == FOLDER_TYPE.PUBLIC_BOARDS ||
-        e.target.closest("li")?.id.split("_")[1] == FOLDER_TYPE.DELETED_BOARDS
-      ) {
-        targetElement =
-          e.target.closest(".action-container") ?? new HTMLElement();
-      } else {
-        targetElement = e.target.closest("li") ?? new HTMLElement();
-      }
+    const targetElement = e.target.closest(".action-container");
+    if (targetElement) {
       targetElement.classList.add("drag-over");
       targetElement.classList.remove("no-drag-over");
     }

--- a/frontend/src/components/tree-view/TreeViewContainer.tsx
+++ b/frontend/src/components/tree-view/TreeViewContainer.tsx
@@ -5,13 +5,13 @@ import { TreeView, useOdeClient } from "@edifice-ui/react";
 import { useTranslation } from "react-i18next";
 
 import { useGetFolderTypeData } from "./utils";
+import { DRAG_AND_DROP_TYPE } from "~/core/enums/drag-and-drop-type.enum";
 import { FOLDER_TYPE, MAIN_PAGE_TITLE } from "~/core/enums/folder-type.enum";
 import { Board } from "~/models/board.model";
 import { Folder, IFolderResponse } from "~/models/folder.model";
 import { useFoldersNavigation } from "~/providers/FoldersNavigationProvider";
 import { useMoveBoardsMutation } from "~/services/api/boards.service";
 import { UserRights } from "~/utils/share.utils";
-import { DRAG_AND_DROP_TYPE } from "~/core/enums/drag-and-drop-type.enum";
 
 type TreeViewContainerProps = {
   folderType: FOLDER_TYPE;

--- a/frontend/src/components/tree-view/TreeViewContainer.tsx
+++ b/frontend/src/components/tree-view/TreeViewContainer.tsx
@@ -11,6 +11,7 @@ import { Folder, IFolderResponse } from "~/models/folder.model";
 import { useFoldersNavigation } from "~/providers/FoldersNavigationProvider";
 import { useMoveBoardsMutation } from "~/services/api/boards.service";
 import { UserRights } from "~/utils/share.utils";
+import { DRAG_AND_DROP_TYPE } from "~/core/enums/drag-and-drop-type.enum";
 
 type TreeViewContainerProps = {
   folderType: FOLDER_TYPE;
@@ -69,16 +70,16 @@ export const TreeViewContainer: React.FunctionComponent<
   const removeFolderHighlight = (e: React.ChangeEvent<HTMLInputElement>) => {
     const targetElement = e.target.closest(".action-container");
     if (targetElement) {
-      targetElement.classList.add("no-drag-over");
-      targetElement.classList.remove("drag-over");
+      targetElement.classList.add(DRAG_AND_DROP_TYPE.NO_DRAG_OVER);
+      targetElement.classList.remove(DRAG_AND_DROP_TYPE.DRAG_OVER);
     }
   };
 
   const handleDragOver = (e: React.ChangeEvent<HTMLInputElement>) => {
     const targetElement = e.target.closest(".action-container");
     if (targetElement) {
-      targetElement.classList.add("drag-over");
-      targetElement.classList.remove("no-drag-over");
+      targetElement.classList.add(DRAG_AND_DROP_TYPE.DRAG_OVER);
+      targetElement.classList.remove(DRAG_AND_DROP_TYPE.NO_DRAG_OVER);
     }
 
     e.preventDefault();

--- a/frontend/src/core/enums/drag-and-drop-type.enum.ts
+++ b/frontend/src/core/enums/drag-and-drop-type.enum.ts
@@ -1,0 +1,4 @@
+export enum DRAG_AND_DROP_TYPE {
+  DRAG_OVER = "drag-over",
+  NO_DRAG_OVER = "no-drag-over",
+}


### PR DESCRIPTION
## Describe your changes
Fix highlighting of folder with subfolder when drag and dropping (it would highlight the entire section of the folder and its list of subfolders instead of just the folder)

## Checklist tests
Check if the highlights of the folders while DnDing are working properly on the treeview

## Issue ticket number and link
[MAG-390](https://jira.support-ent.fr/browse/MAG-390)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

