### PR TITLE
fix(toaster) : #MAG-355 fix open button not working

### DIFF
--- a/frontend/src/components/toaster-container/ToasterContainer.tsx
+++ b/frontend/src/components/toaster-container/ToasterContainer.tsx
@@ -61,6 +61,7 @@ export const ToasterContainer = ({
     selectedFolders,
     selectedFoldersIds,
     selectedFolderRights,
+    handleSelect,
   } = useFoldersNavigation();
   const { selectedBoardsIds, selectedBoards, selectedBoardRights } =
     useBoardsNavigation();
@@ -198,7 +199,14 @@ export const ToasterContainer = ({
                       type="button"
                       color="primary"
                       variant="filled"
-                      onClick={function Ga() {}}
+                      onClick={() => {
+                        selectedBoardsIds.length == 1 //if we selected a board, open it (TODO), else open the folder
+                          ? undefined
+                          : handleSelect(
+                              selectedFoldersIds[0],
+                              FOLDER_TYPE.MY_BOARDS, //the button being there only if not in trash, and no folders being in "Public boards", the folder has to be in "My boards"
+                            );
+                      }}
                     >
                       {t("magneto.open")}
                     </Button>


### PR DESCRIPTION
## Describe your changes
fix open button not working (not implemented for boards, but working for folders)

## Checklist tests
Try to open folders with the "Open" button from the toaster

## Issue ticket number and link
[MAG-355](https://jira.support-ent.fr/browse/MAG-355)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

