### PR TITLE
fix(favorite) : #MAG-458 add loading screen and fix content not centered in favorites view

### DIFF
--- a/frontend/src/components/board-card/style.ts
+++ b/frontend/src/components/board-card/style.ts
@@ -9,7 +9,7 @@ import {
   Typography,
 } from "@mui/material";
 
-const handleCardSize = (zoomLevel: number) => {
+export const handleCardSize = (zoomLevel: number) => {
   let cardSize = { width: "269px", height: "264px" };
 
   switch (zoomLevel) {

--- a/frontend/src/components/board-view/BoardView.tsx
+++ b/frontend/src/components/board-view/BoardView.tsx
@@ -17,12 +17,14 @@ import { ZoomComponent } from "../zoom-component/ZoomComponent";
 import { LAYOUT_TYPE } from "~/core/enums/layout-type.enum";
 import { useSideMenuData } from "~/hooks/useSideMenuData";
 import { useBoard } from "~/providers/BoardProvider";
+import { LoadingScreen } from "@edifice-ui/react";
 
 export const BoardView: FC = () => {
   const { t } = useTranslation("magneto");
 
   const sideMenuData = useSideMenuData();
-  const { board, zoomLevel, zoomIn, zoomOut, resetZoom } = useBoard();
+  const { board, zoomLevel, zoomIn, zoomOut, resetZoom, isLoading } =
+    useBoard();
   const headerHeight = useHeaderHeight();
 
   useEffect(() => {
@@ -45,7 +47,9 @@ export const BoardView: FC = () => {
     }
   };
 
-  return (
+  return isLoading ? (
+    <LoadingScreen position={false} />
+  ) : (
     <BoardViewWrapper layout={board.layoutType}>
       <HeaderView />
       <SideMenu sideMenuData={sideMenuData} />

--- a/frontend/src/components/board-view/BoardView.tsx
+++ b/frontend/src/components/board-view/BoardView.tsx
@@ -2,6 +2,7 @@ import { FC, useEffect } from "react";
 
 import "./BoardView.scss";
 
+import { LoadingScreen } from "@edifice-ui/react";
 import { mdiKeyboardBackspace } from "@mdi/js";
 import Icon from "@mdi/react";
 import { useTranslation } from "react-i18next";
@@ -17,7 +18,6 @@ import { ZoomComponent } from "../zoom-component/ZoomComponent";
 import { LAYOUT_TYPE } from "~/core/enums/layout-type.enum";
 import { useSideMenuData } from "~/hooks/useSideMenuData";
 import { useBoard } from "~/providers/BoardProvider";
-import { LoadingScreen } from "@edifice-ui/react";
 
 export const BoardView: FC = () => {
   const { t } = useTranslation("magneto");

--- a/frontend/src/components/magnets-collection/FavoriteViewByBoard.tsx
+++ b/frontend/src/components/magnets-collection/FavoriteViewByBoard.tsx
@@ -1,16 +1,15 @@
 import { FunctionComponent } from "react";
 
 import FileCopyOutlinedIcon from "@mui/icons-material/FileCopyOutlined";
-import { animated } from "@react-spring/web";
 import { useTranslation } from "react-i18next";
 
+import { StyledGridBox } from "./style";
 import { BoardCard } from "../board-card/BoardCard";
 import { EmptyState } from "../empty-state/EmptyState";
 import { usePredefinedToasts } from "~/hooks/usePredefinedToasts";
 import { Board } from "~/models/board.model";
 import { Card as CardModel } from "~/models/card.model";
 import { useDuplicateBoardMutation } from "~/services/api/boards.service";
-import { StyledGridBox } from "./style";
 
 type FavoriteViewByBoardProps = {
   boardsWithCards: Board[];
@@ -22,7 +21,7 @@ type FavoriteViewByBoardProps = {
 
 export const FavoriteViewByBoard: FunctionComponent<
   FavoriteViewByBoardProps
-> = ({ boardsWithCards, searchText, springs }: FavoriteViewByBoardProps) => {
+> = ({ boardsWithCards, searchText }: FavoriteViewByBoardProps) => {
   const { t } = useTranslation("magneto");
   const zoomLevel = 2;
   const [duplicateBoard] = useDuplicateBoardMutation();

--- a/frontend/src/components/magnets-collection/FavoriteViewByBoard.tsx
+++ b/frontend/src/components/magnets-collection/FavoriteViewByBoard.tsx
@@ -10,6 +10,7 @@ import { usePredefinedToasts } from "~/hooks/usePredefinedToasts";
 import { Board } from "~/models/board.model";
 import { Card as CardModel } from "~/models/card.model";
 import { useDuplicateBoardMutation } from "~/services/api/boards.service";
+import { StyledGridBox } from "./style";
 
 type FavoriteViewByBoardProps = {
   boardsWithCards: Board[];
@@ -23,6 +24,7 @@ export const FavoriteViewByBoard: FunctionComponent<
   FavoriteViewByBoardProps
 > = ({ boardsWithCards, searchText, springs }: FavoriteViewByBoardProps) => {
   const { t } = useTranslation("magneto");
+  const zoomLevel = 2;
   const [duplicateBoard] = useDuplicateBoardMutation();
 
   const duplicateBoardsAndToast = usePredefinedToasts({
@@ -65,7 +67,7 @@ export const FavoriteViewByBoard: FunctionComponent<
                   {" " + t("magneto.cards.collection.board.duplicate")}
                 </span>
               </div>
-              <animated.ul className="grid ps-0 list-unstyled mb-24">
+              <StyledGridBox zoomLevel={zoomLevel}>
                 {board.cards
                   .filter(
                     (card: CardModel) =>
@@ -76,18 +78,13 @@ export const FavoriteViewByBoard: FunctionComponent<
                           .includes(searchText.toLowerCase())),
                   )
                   .map((card: CardModel) => (
-                    <animated.li
-                      className="g-col-4 z-1 boardSizing"
+                    <BoardCard
                       key={card.id}
-                      style={{
-                        position: "relative",
-                        ...springs,
-                      }}
-                    >
-                      <BoardCard card={card} zoomLevel={2}></BoardCard>
-                    </animated.li>
+                      card={card}
+                      zoomLevel={zoomLevel}
+                    />
                   ))}
-              </animated.ul>
+              </StyledGridBox>
             </div>
           </li>
         ))}

--- a/frontend/src/components/magnets-collection/FavoriteViewByCard.tsx
+++ b/frontend/src/components/magnets-collection/FavoriteViewByCard.tsx
@@ -1,9 +1,11 @@
 import { FunctionComponent } from "react";
+
 import { useTranslation } from "react-i18next";
+
+import { StyledGridBox } from "./style";
 import { BoardCard } from "../board-card/BoardCard";
 import { EmptyState } from "../empty-state/EmptyState";
 import { Card, Card as CardModel } from "~/models/card.model";
-import { StyledGridBox } from "./style";
 
 type FavoriteViewByCardProps = {
   cardsData: CardModel[];

--- a/frontend/src/components/magnets-collection/FavoriteViewByCard.tsx
+++ b/frontend/src/components/magnets-collection/FavoriteViewByCard.tsx
@@ -1,11 +1,9 @@
 import { FunctionComponent } from "react";
-
-import { animated } from "@react-spring/web";
 import { useTranslation } from "react-i18next";
-
 import { BoardCard } from "../board-card/BoardCard";
 import { EmptyState } from "../empty-state/EmptyState";
-import { Card as CardModel } from "~/models/card.model";
+import { Card, Card as CardModel } from "~/models/card.model";
+import { StyledGridBox } from "./style";
 
 type FavoriteViewByCardProps = {
   cardsData: CardModel[];
@@ -18,9 +16,9 @@ type FavoriteViewByCardProps = {
 export const FavoriteViewByCard: FunctionComponent<FavoriteViewByCardProps> = ({
   cardsData,
   searchText,
-  springs,
 }: FavoriteViewByCardProps) => {
   const { t } = useTranslation("magneto");
+  const zoomLevel = 2;
 
   const filteredCards = cardsData.filter(
     (card: CardModel) =>
@@ -30,22 +28,11 @@ export const FavoriteViewByCard: FunctionComponent<FavoriteViewByCardProps> = ({
   );
 
   return filteredCards.length ? (
-    <div>
-      <animated.ul className="grid ps-0 list-unstyled mb-24">
-        {filteredCards.map((card: CardModel) => (
-          <animated.li
-            className="g-col-4 z-1 boardSizing"
-            key={card.id}
-            style={{
-              position: "relative",
-              ...springs,
-            }}
-          >
-            <BoardCard card={card} zoomLevel={2}></BoardCard>
-          </animated.li>
-        ))}
-      </animated.ul>
-    </div>
+    <StyledGridBox zoomLevel={zoomLevel}>
+      {filteredCards.map((card: Card) => (
+        <BoardCard key={card.id} card={card} zoomLevel={zoomLevel} />
+      ))}
+    </StyledGridBox>
   ) : (
     <EmptyState title={t("magneto.cards.empty.text")} />
   );

--- a/frontend/src/components/magnets-collection/style.ts
+++ b/frontend/src/components/magnets-collection/style.ts
@@ -1,4 +1,5 @@
 import { Box, styled } from "@mui/material";
+
 import { handleCardSize } from "../board-card/style";
 
 export const StyledGridBox = styled(Box, {

--- a/frontend/src/components/magnets-collection/style.ts
+++ b/frontend/src/components/magnets-collection/style.ts
@@ -1,0 +1,12 @@
+import { Box, styled } from "@mui/material";
+import { handleCardSize } from "../board-card/style";
+
+export const StyledGridBox = styled(Box, {
+  shouldForwardProp: (prop) => prop !== "zoomLevel",
+})<{ zoomLevel: number }>(({ zoomLevel }) => ({
+  display: "grid",
+  gridTemplateColumns: `repeat(auto-fill, ${handleCardSize(zoomLevel).width})`,
+  gap: "3rem",
+  justifyContent: "center",
+  width: "100%",
+}));

--- a/frontend/src/providers/BoardProvider/index.tsx
+++ b/frontend/src/providers/BoardProvider/index.tsx
@@ -27,7 +27,7 @@ export const useBoard = () => {
 export const BoardProvider: FC<BoardProviderProps> = ({ children }) => {
   const [zoomLevel, setZoomLevel] = useState<number>(3);
   const { id = "" } = useParams();
-  const { data: boardData } = useGetBoardDataQuery(id);
+  const { data: boardData, isLoading } = useGetBoardDataQuery(id);
 
   const zoomIn = (): void => {
     if (zoomLevel < 5) setZoomLevel(zoomLevel + 1);
@@ -66,6 +66,7 @@ export const BoardProvider: FC<BoardProviderProps> = ({ children }) => {
       zoomIn,
       zoomOut,
       resetZoom,
+      isLoading,
     }),
     [board, zoomLevel],
   );

--- a/frontend/src/providers/BoardProvider/types.ts
+++ b/frontend/src/providers/BoardProvider/types.ts
@@ -14,6 +14,7 @@ export type BoardContextType = {
   zoomIn: () => void;
   zoomOut: () => void;
   resetZoom: () => void;
+  isLoading: boolean;
 };
 
 export type Section = {


### PR DESCRIPTION
## Describe your changes
fix content not centered in favorites view
add LoadingScreen on loading a new board

## Checklist tests
Vérifier que les deux vues des favoris dans la page d'accueil fonctionnent correctement, notamment avec des tableaux à 1 ou 2 favoris seulement pour vérifier que l'alignement fonctionne bien.

## Issue ticket number and link
[MAG-458](https://jira.support-ent.fr/browse/MAG-458)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

