### PR TITLE
fix(boardview) : #MAG-449 fix read-only view missing

### DIFF
--- a/backend/src/main/java/fr/cgi/magneto/core/constants/Field.java
+++ b/backend/src/main/java/fr/cgi/magneto/core/constants/Field.java
@@ -31,6 +31,7 @@ public class Field {
     public static final String ISPUBLIC = "isPublic";
 
     public static final String SHARED = "shared";
+    public static final String RIGHTS = "rights";
     public static final String INHERITEDSHARES = "inheritedShares";
     public static final String ISSHARED = "isShared";
     public static final String SORTBY = "sortBy";

--- a/backend/src/main/java/fr/cgi/magneto/model/boards/Board.java
+++ b/backend/src/main/java/fr/cgi/magneto/model/boards/Board.java
@@ -36,6 +36,7 @@ public class Board implements Model<Board> {
     private Boolean displayNbFavorites;
     private int nbCards;
     private int nbCardsSections;
+    private JsonArray rights;
 
 
     @SuppressWarnings("unchecked")
@@ -70,6 +71,7 @@ public class Board implements Model<Board> {
         }
         if (board.containsKey(Field.NBCARDSSECTIONS))
             this.nbCardsSections = board.getInteger(Field.NBCARDSSECTIONS);
+        this.rights = board.getJsonArray(Field.RIGHTS, new JsonArray());
 
     }
 
@@ -294,6 +296,14 @@ public class Board implements Model<Board> {
         this.nbCardsSections = nbCardsSections;
     }
 
+    public void setRights(JsonArray rights) {
+        this.rights = rights;
+    }
+
+    public JsonArray getRights() {
+        return this.rights;
+    }
+
     public Board reset() {
         this.setId(null);
         this.setPublic(false);
@@ -324,7 +334,8 @@ public class Board implements Model<Board> {
                 .put(Field.LAYOUTTYPE, this.getLayoutType())
                 .put(Field.CANCOMMENT, this.canComment())
                 .put(Field.DISPLAY_NB_FAVORITES, this.displayNbFavorites())
-                .put(Field.TAGS, this.tags());
+                .put(Field.TAGS, this.tags())
+                .put(Field.RIGHTS, this.getRights());
     }
 
     @Override

--- a/backend/src/main/java/fr/cgi/magneto/service/impl/DefaultBoardService.java
+++ b/backend/src/main/java/fr/cgi/magneto/service/impl/DefaultBoardService.java
@@ -404,7 +404,15 @@ public class DefaultBoardService implements BoardService {
                 JsonArray result = either.right().getValue()
                         .getJsonObject(Field.CURSOR, new JsonObject())
                         .getJsonArray(Field.FIRSTBATCH, new JsonArray());
-                promise.complete(ModelHelper.toList(result, Board.class));
+
+                List<JsonObject> boardList = result.stream()
+                        .filter(JsonObject.class::isInstance)
+                        .map(JsonObject.class::cast)
+                        .map(this::addNormalizedShares)
+                        .collect(Collectors.toList());
+                System.out.println(boardList);
+                System.out.println(ModelHelper.toList(new JsonArray(boardList), Board.class));
+                promise.complete(ModelHelper.toList(new JsonArray(boardList), Board.class));
             }
         }));
 

--- a/backend/src/main/java/fr/cgi/magneto/service/impl/DefaultBoardService.java
+++ b/backend/src/main/java/fr/cgi/magneto/service/impl/DefaultBoardService.java
@@ -410,8 +410,6 @@ public class DefaultBoardService implements BoardService {
                         .map(JsonObject.class::cast)
                         .map(this::addNormalizedShares)
                         .collect(Collectors.toList());
-                System.out.println(boardList);
-                System.out.println(ModelHelper.toList(new JsonArray(boardList), Board.class));
                 promise.complete(ModelHelper.toList(new JsonArray(boardList), Board.class));
             }
         }));

--- a/backend/src/test/java/fr/cgi/magneto/model/BoardTest.java
+++ b/backend/src/test/java/fr/cgi/magneto/model/BoardTest.java
@@ -29,6 +29,7 @@ public class BoardTest {
             .put("ownerName", "ownerName")
             .put("shared", new JsonArray())
             .put("tags", new JsonArray())
+            .put("rights", new JsonArray())
             .put("displayNbFavorites", false);
 
     @Test

--- a/frontend/src/components/board-view/BoardView.tsx
+++ b/frontend/src/components/board-view/BoardView.tsx
@@ -23,8 +23,15 @@ export const BoardView: FC = () => {
   const { t } = useTranslation("magneto");
 
   const sideMenuData = useSideMenuData();
-  const { board, zoomLevel, zoomIn, zoomOut, resetZoom, isLoading } =
-    useBoard();
+  const {
+    board,
+    zoomLevel,
+    zoomIn,
+    zoomOut,
+    resetZoom,
+    isLoading,
+    boardRights,
+  } = useBoard();
   const headerHeight = useHeaderHeight();
 
   useEffect(() => {

--- a/frontend/src/components/board-view/BoardView.tsx
+++ b/frontend/src/components/board-view/BoardView.tsx
@@ -59,7 +59,7 @@ export const BoardView: FC = () => {
   ) : (
     <BoardViewWrapper layout={board.layoutType}>
       <HeaderView />
-      <SideMenu sideMenuData={sideMenuData} />
+      {boardRights?.contrib && <SideMenu sideMenuData={sideMenuData} />}
       <BoardBodyWrapper layout={board.layoutType} headerHeight={headerHeight}>
         {displayLayout()}
         {board.backgroundUrl ? (

--- a/frontend/src/components/cards-horizontal-layout/CardsHorizontalLayout.tsx
+++ b/frontend/src/components/cards-horizontal-layout/CardsHorizontalLayout.tsx
@@ -15,7 +15,7 @@ import { Card } from "~/models/card.model";
 import { useBoard } from "~/providers/BoardProvider";
 
 export const CardsHorizontalLayout: FC = () => {
-  const { board, zoomLevel } = useBoard();
+  const { board, zoomLevel, boardRights } = useBoard();
 
   if (!board.sections?.length) return null;
 
@@ -42,11 +42,13 @@ export const CardsHorizontalLayout: FC = () => {
           </UlWrapper>
         </SectionWrapper>
       ))}
-      <SectionWrapper isLast={true}>
-        <Box sx={sectionNameWrapperStyle}>
-          <SectionName section={null} />
-        </Box>
-      </SectionWrapper>
+      {boardRights?.contrib && (
+        <SectionWrapper isLast={true}>
+          <Box sx={sectionNameWrapperStyle}>
+            <SectionName section={null} />
+          </Box>
+        </SectionWrapper>
+      )}
     </Box>
   );
 };

--- a/frontend/src/components/cards-vertical-layout/CardsVerticalLayout.tsx
+++ b/frontend/src/components/cards-vertical-layout/CardsVerticalLayout.tsx
@@ -14,20 +14,27 @@ import { SectionName } from "../section-name/SectionName";
 import { useBoard } from "~/providers/BoardProvider";
 
 export const CardsVerticalLayout: FC = () => {
-  const { board, zoomLevel } = useBoard();
+  const { board, zoomLevel, boardRights } = useBoard();
 
   if (!board.sections?.length) return null;
 
   return (
     <Box sx={mainWrapperProps}>
       {board.sections.map((section) => (
-        <SectionWrapper key={section._id} sectionNumber={board.sections.length}>
+        <SectionWrapper
+          key={section._id}
+          sectionNumber={
+            boardRights?.contrib
+              ? board.sections.length + 1
+              : board.sections.length
+          }
+        >
           <Box sx={sectionNameWrapperStyle}>
             <SectionName section={section} />
           </Box>
           <CardsWrapper zoomLevel={zoomLevel}>
             {section.cards.map((card) => (
-              <CardWrapper key={card.id} zoomLevel={zoomLevel}>
+              <CardWrapper key={card.id}>
                 <BoardCard
                   card={card}
                   zoomLevel={zoomLevel}
@@ -39,11 +46,13 @@ export const CardsVerticalLayout: FC = () => {
           </CardsWrapper>
         </SectionWrapper>
       ))}
-      <SectionWrapper sectionNumber={board.sections.length} isLast={true}>
-        <Box sx={sectionNameWrapperStyle}>
-          <SectionName section={null} />
-        </Box>
-      </SectionWrapper>
+      {boardRights?.contrib && (
+        <SectionWrapper sectionNumber={board.sections.length} isLast={true}>
+          <Box sx={sectionNameWrapperStyle}>
+            <SectionName section={null} />
+          </Box>
+        </SectionWrapper>
+      )}
     </Box>
   );
 };

--- a/frontend/src/components/cards-vertical-layout/style.ts
+++ b/frontend/src/components/cards-vertical-layout/style.ts
@@ -4,10 +4,11 @@ import { SectionWrapperProps } from "./types";
 import { handleCardSize } from "../board-card/style";
 
 const prepareWidth: (sectionNumber: number) => string = (sectionNumber) => {
-  if (sectionNumber === 1) return "50%";
-  if (sectionNumber === 2) return "33%";
-  if (sectionNumber === 3) return "25%";
-  if (sectionNumber > 3) return "22%";
+  if (sectionNumber === 1) return "100%";
+  if (sectionNumber === 2) return "50%";
+  if (sectionNumber === 3) return "33%";
+  if (sectionNumber === 4) return "25%";
+  if (sectionNumber > 4) return "22%";
   return "";
 };
 

--- a/frontend/src/components/section-name/SectionName.tsx
+++ b/frontend/src/components/section-name/SectionName.tsx
@@ -113,7 +113,7 @@ export const SectionName: FC<SectionNameProps> = ({ section }) => {
         disabled={!boardRights?.contrib}
         fullWidth
       />
-      {section && (
+      {section && boardRights?.contrib && (
         <IconButton
           size="large"
           sx={iconButtonStyle}

--- a/frontend/src/components/section-name/SectionName.tsx
+++ b/frontend/src/components/section-name/SectionName.tsx
@@ -36,6 +36,7 @@ export const SectionName: FC<SectionNameProps> = ({ section }) => {
   const inputWrapperRef = useRef<HTMLDivElement>(null);
   const {
     board: { id: boardId },
+    boardRights,
   } = useBoard();
 
   useEffect(() => {
@@ -109,6 +110,7 @@ export const SectionName: FC<SectionNameProps> = ({ section }) => {
         onBlur={handleKeyDownAndBlur}
         onKeyDown={handleKeyDown}
         ref={inputWrapperRef}
+        disabled={!boardRights?.contrib}
         fullWidth
       />
       {section && (

--- a/frontend/src/components/section-name/style.ts
+++ b/frontend/src/components/section-name/style.ts
@@ -20,6 +20,7 @@ export const inputStyle = {
     lineHeight: "1.5rem",
     padding: ".5rem 0 .5rem 1.5rem",
     boxSizing: "border-box",
+    textOverflow: "ellipsis",
   },
 };
 

--- a/frontend/src/providers/BoardProvider/index.tsx
+++ b/frontend/src/providers/BoardProvider/index.tsx
@@ -7,14 +7,14 @@ import {
   useState,
 } from "react";
 
+import { checkUserRight } from "@edifice-ui/react";
+import { RightRole } from "edifice-ts-client";
 import { useParams } from "react-router-dom";
 
 import { BoardContextType, BoardProviderProps } from "./types";
 import { fetchZoomPreference, updateZoomPreference } from "./utils";
 import { Board, IBoardItemResponse } from "~/models/board.model";
 import { useGetBoardDataQuery } from "~/services/api/boardData.service";
-import { RightRole } from "edifice-ts-client";
-import { checkUserRight } from "@edifice-ui/react";
 
 const BoardContext = createContext<BoardContextType | null>(null);
 

--- a/frontend/src/providers/BoardProvider/index.tsx
+++ b/frontend/src/providers/BoardProvider/index.tsx
@@ -69,8 +69,8 @@ export const BoardProvider: FC<BoardProviderProps> = ({ children }) => {
   }, [zoomLevel]);
 
   useEffect(() => {
-    if (boardData) updateRights(boardData.rights);
-  }, [boardData]);
+    if (board) updateRights(board.rights);
+  }, [board]);
 
   const value = useMemo<BoardContextType>(
     () => ({

--- a/frontend/src/providers/BoardProvider/index.tsx
+++ b/frontend/src/providers/BoardProvider/index.tsx
@@ -13,6 +13,8 @@ import { BoardContextType, BoardProviderProps } from "./types";
 import { fetchZoomPreference, updateZoomPreference } from "./utils";
 import { Board, IBoardItemResponse } from "~/models/board.model";
 import { useGetBoardDataQuery } from "~/services/api/boardData.service";
+import { RightRole } from "edifice-ts-client";
+import { checkUserRight } from "@edifice-ui/react";
 
 const BoardContext = createContext<BoardContextType | null>(null);
 
@@ -28,6 +30,10 @@ export const BoardProvider: FC<BoardProviderProps> = ({ children }) => {
   const [zoomLevel, setZoomLevel] = useState<number>(3);
   const { id = "" } = useParams();
   const { data: boardData, isLoading } = useGetBoardDataQuery(id);
+  const [boardRights, setBoardRights] = useState<Record<
+    RightRole,
+    boolean
+  > | null>(null);
 
   const zoomIn = (): void => {
     if (zoomLevel < 5) setZoomLevel(zoomLevel + 1);
@@ -50,6 +56,10 @@ export const BoardProvider: FC<BoardProviderProps> = ({ children }) => {
     setZoomLevel(zoom);
   };
 
+  const updateRights = async (rights: any) => {
+    setBoardRights(await checkUserRight(rights));
+  };
+
   useEffect(() => {
     prepareZoom();
   }, []);
@@ -57,6 +67,10 @@ export const BoardProvider: FC<BoardProviderProps> = ({ children }) => {
   useEffect(() => {
     updateZoomPreference(zoomLevel);
   }, [zoomLevel]);
+
+  useEffect(() => {
+    if (boardData) updateRights(boardData.rights);
+  }, [boardData]);
 
   const value = useMemo<BoardContextType>(
     () => ({
@@ -67,8 +81,9 @@ export const BoardProvider: FC<BoardProviderProps> = ({ children }) => {
       zoomOut,
       resetZoom,
       isLoading,
+      boardRights,
     }),
-    [board, zoomLevel],
+    [board, zoomLevel, boardRights],
   );
 
   return (

--- a/frontend/src/providers/BoardProvider/index.tsx
+++ b/frontend/src/providers/BoardProvider/index.tsx
@@ -69,8 +69,9 @@ export const BoardProvider: FC<BoardProviderProps> = ({ children }) => {
   }, [zoomLevel]);
 
   useEffect(() => {
-    if (board) updateRights(board.rights);
-  }, [board]);
+    if (boardData)
+      updateRights(new Board().build(boardData as IBoardItemResponse).rights);
+  }, [boardData]);
 
   const value = useMemo<BoardContextType>(
     () => ({

--- a/frontend/src/providers/BoardProvider/types.ts
+++ b/frontend/src/providers/BoardProvider/types.ts
@@ -1,5 +1,6 @@
-import { RightRole } from "edifice-ts-client";
 import { Dispatch, ReactNode, SetStateAction } from "react";
+
+import { RightRole } from "edifice-ts-client";
 
 import { Board } from "~/models/board.model";
 import { Card } from "~/models/card.model";

--- a/frontend/src/providers/BoardProvider/types.ts
+++ b/frontend/src/providers/BoardProvider/types.ts
@@ -1,3 +1,4 @@
+import { RightRole } from "edifice-ts-client";
 import { Dispatch, ReactNode, SetStateAction } from "react";
 
 import { Board } from "~/models/board.model";
@@ -15,6 +16,7 @@ export type BoardContextType = {
   zoomOut: () => void;
   resetZoom: () => void;
   isLoading: boolean;
+  boardRights: Record<RightRole, boolean> | null;
 };
 
 export type Section = {


### PR DESCRIPTION
## Describe your changes
Fix the view being the same when having only the read rights as when having upper rights (read-only mode have no scrollbar, no creation section, no bullet menu, and can't interact with section names).

## Checklist tests
Il faut vérifier que la vue avec contrib ou + ne soit pas altérée et que la vue en read-only n'ait pas de scrollbar, pas de section de création, pas de bullet menu au niveau de la section et ne puisse pas intéragir avec les noms de sections.

## Issue ticket number and link
[MAG-449](https://jira.support-ent.fr/browse/MAG-449)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

