### PR TITLE
fix: #CGIDEV-284, deactivate jar minification

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>io.edifice</groupId>
         <artifactId>app-parent</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
     </parent>
     <groupId>fr.cgi</groupId>
     <artifactId>magneto</artifactId>
-    <version>2.5-SNAPSHOT</version>
+    <version>2.5-develop-b2school-SNAPSHOT</version>
     <scm>
         <connection>scm:git:https://github.com/OPEN-ENT-NG/magneto.git</connection>
         <developerConnection>scm:git:https://github.com/OPEN-ENT-NG/magneto.git</developerConnection>
@@ -41,6 +41,7 @@
         <apachePoiVersion>5.2.3</apachePoiVersion>
         <jsoupVersion>1.18.3</jsoupVersion>
         <thumbnailatorVersion>0.4.20</thumbnailatorVersion>
+        <shade.minimizeJar>false</shade.minimizeJar>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
## Describe your changes

This PR update the version of the parent pom to use to be able to deactivate jar minification which causes an error while exporting boards.

Before being accepted, the PR on edifice-parent needs to be accepted and the final version of app-parent fixed.
https://github.com/edificeio/edifice-parent/pull/3

## Checklist tests

## Issue ticket number and link

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [x] If it is a consequent feature, I have added thorough tests.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to this project (must specify in **Description**)
