### PR TITLE
fix(treeview) : #MAG-519 fix all initial folders having the same label

### DIFF
--- a/frontend/src/components/tree-view/utils.ts
+++ b/frontend/src/components/tree-view/utils.ts
@@ -1,5 +1,7 @@
 import { FOLDER_TYPE } from "~/core/enums/folder-type.enum";
 import { FolderObjectState } from "~/providers/FoldersNavigationProvider/types";
+import { useInitialDeletedBoardsFolderObject } from "~/providers/FoldersNavigationProvider/useInitialDeletedBoardsFolderObject";
+import { useInitialMyBoardsFolderObject } from "~/providers/FoldersNavigationProvider/useInitialMyBoardsFolderObject";
 import { useInitialPublicFolderObject } from "~/providers/FoldersNavigationProvider/useInitialPublicFolderObject";
 
 export const useGetFolderTypeData = (
@@ -7,6 +9,9 @@ export const useGetFolderTypeData = (
   folderObject: FolderObjectState,
 ) => {
   const publicFolderObject = useInitialPublicFolderObject();
+  const myBoardsFolderObject = useInitialMyBoardsFolderObject();
+  const deletedBoardsFolderObject = useInitialDeletedBoardsFolderObject();
+
   if (folderObject.myFolderObject && folderObject.deletedFolderObject) {
     switch (folderType) {
       case FOLDER_TYPE.MY_BOARDS:
@@ -19,5 +24,15 @@ export const useGetFolderTypeData = (
         return folderObject.myFolderObject;
     }
   }
-  return publicFolderObject;
+
+  switch (folderType) {
+    case FOLDER_TYPE.MY_BOARDS:
+      return myBoardsFolderObject;
+    case FOLDER_TYPE.PUBLIC_BOARDS:
+      return publicFolderObject;
+    case FOLDER_TYPE.DELETED_BOARDS:
+      return deletedBoardsFolderObject;
+    default:
+      return publicFolderObject;
+  }
 };

--- a/frontend/src/providers/FoldersNavigationProvider/useInitialDeletedBoardsFolderObject.ts
+++ b/frontend/src/providers/FoldersNavigationProvider/useInitialDeletedBoardsFolderObject.ts
@@ -1,0 +1,15 @@
+import { useTranslation } from "react-i18next";
+
+import { FOLDER_TYPE } from "~/core/enums/folder-type.enum";
+import { FolderTreeNavItem } from "~/models/folder-tree.model";
+
+export const useInitialDeletedBoardsFolderObject = () => {
+  const { t } = useTranslation("magneto");
+  const folderObject = new FolderTreeNavItem({
+    id: FOLDER_TYPE.DELETED_BOARDS,
+    title: t("magneto.trash"),
+    parentId: "",
+    section: true,
+  });
+  return folderObject;
+};

--- a/frontend/src/providers/FoldersNavigationProvider/useInitialMyBoardsFolderObject.ts
+++ b/frontend/src/providers/FoldersNavigationProvider/useInitialMyBoardsFolderObject.ts
@@ -1,0 +1,15 @@
+import { useTranslation } from "react-i18next";
+
+import { FOLDER_TYPE } from "~/core/enums/folder-type.enum";
+import { FolderTreeNavItem } from "~/models/folder-tree.model";
+
+export const useInitialMyBoardsFolderObject = () => {
+  const { t } = useTranslation("magneto");
+  const folderObject = new FolderTreeNavItem({
+    id: FOLDER_TYPE.MY_BOARDS,
+    title: t("magneto.my.boards"),
+    parentId: "",
+    section: true,
+  });
+  return folderObject;
+};


### PR DESCRIPTION
## Describe your changes
fix all initial folders having the same label when starting the main page (all folders are being "Tableaux de la plateforme)

## Checklist tests
Check on startup page if labels are now correct

## Issue ticket number and link
[MAG-519](https://jira.support-ent.fr/browse/MAG-519)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)
